### PR TITLE
[Queries] Respect `maxResults` parameter when fetching query results

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -14,7 +14,7 @@ type (
 	GetQueryResultsResponse struct {
 		JobReference *bigqueryv2.JobReference `json:"jobReference"`
 		Schema       *bigqueryv2.TableSchema  `json:"schema"`
-		Rows         []*TableRow              `json:"rows"`
+		Rows         []*TableRow              `json:"rows,omitempty"`
 		TotalRows    uint64                   `json:"totalRows,string"`
 		JobComplete  bool                     `json:"jobComplete"`
 		TotalBytes   uint64                   `json:"-"`

--- a/server/handler.go
+++ b/server/handler.go
@@ -1014,7 +1014,7 @@ func (h *jobsGetQueryResultsHandler) Handle(ctx context.Context, r *jobsGetQuery
 	}
 
 	if r.maxResults != maxResultsDefaultValue {
-		rows = rows[:r.maxResults]
+		rows = rows[:min(int64(len(rows)), r.maxResults)]
 	}
 
 	return &internaltypes.GetQueryResultsResponse{


### PR DESCRIPTION
Found while writing the regression test for goccy/go-zetasqlite#132.

Opened under goccy/bigquery-emulator#262