### PR TITLE
Increase request timeout to avoid `failed to add job: job already created` errors

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -212,7 +212,7 @@ func (s *Server) Serve(ctx context.Context, httpAddr, grpcAddr string) error {
 	httpServer := &http.Server{
 		Handler:      s.Handler,
 		Addr:         httpAddr,
-		WriteTimeout: 15 * time.Second,
+		WriteTimeout: 5 * time.Minute,
 		ReadTimeout:  15 * time.Second,
 	}
 	s.httpServer = httpServer


### PR DESCRIPTION
We were seeing the emulator become unresponsive when complex queries were run. The 15 second timeout closed the HTTP connection and further requests to re-insert the BigQuery job would fail due to a `job already exists` error.

This bumps the timeout to a slightly more reasonable duration.