### PR TITLE
Return immediately from `Job.wait()` if a `Job` has a response set

### DIFF
--- a/internal/metadata/job.go
+++ b/internal/metadata/job.go
@@ -47,8 +47,8 @@ func (j *Job) Wait(ctx context.Context) (*internaltypes.QueryResponse, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if j.response != nil {
-		return j.response, nil
+	if j.response != nil || j.err != nil {
+		return j.response, j.err
 	}
 
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/internal/metadata/job.go
+++ b/internal/metadata/job.go
@@ -47,6 +47,10 @@ func (j *Job) Wait(ctx context.Context) (*internaltypes.QueryResponse, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
+	if j.response != nil {
+		return j.response, nil
+	}
+
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
On my performance refactor feature branch, job insertion was taking ~101ms. I narrowed the slowdown due to the ticker waiting 100ms before returning. This returns immediately if the Job already has a response set.