### PR TITLE
Refactor API data-access pattern to only load what is necessary; use prepared statements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect
 )
 
-replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.7
+replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.8
 
 replace github.com/mattn/go-sqlite3 => github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvK
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048 h1:G8qFbNf/6IWYup4//DcrwsMYvAl80qZk9hEb6Z+UfKc=
 github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.7 h1:wvjkJOGE9xCk4WtzNedjHOPuudqmqn9yz3Son8SPVRQ=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.7/go.mod h1:KVfVr9Lp7/4FH0Eeiunu1Dh274lxKJvWwpQWEkoRkuA=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.8 h1:OFNdqgtpVfUhcU5wIq0Uipxm7eZ+eiolpVGhrEFt1yA=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.8/go.mod h1:KVfVr9Lp7/4FH0Eeiunu1Dh274lxKJvWwpQWEkoRkuA=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -5,12 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/goccy/go-zetasqlite"
-	"reflect"
-	"strings"
-	"time"
-
 	"go.uber.org/zap"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
+	"reflect"
+	"strings"
 
 	"github.com/goccy/bigquery-emulator/internal/connection"
 	"github.com/goccy/bigquery-emulator/internal/logger"
@@ -78,12 +76,7 @@ func (r *Repository) routinePath(projectID, datasetID, routineID string) string 
 	routinePath = append(routinePath, routineID)
 	return strings.Join(routinePath, ".")
 }
-func timer(name string) func() {
-	start := time.Now()
-	return func() {
-		fmt.Printf("%s took %v\n", name, time.Since(start))
-	}
-}
+
 func (r *Repository) CreateTable(ctx context.Context, tx *connection.Tx, table *bigqueryv2.Table) error {
 	if err := tx.ContentRepoMode(); err != nil {
 		return err

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goccy/go-zetasqlite"
 	"reflect"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
@@ -77,7 +78,12 @@ func (r *Repository) routinePath(projectID, datasetID, routineID string) string 
 	routinePath = append(routinePath, routineID)
 	return strings.Join(routinePath, ".")
 }
-
+func timer(name string) func() {
+	start := time.Now()
+	return func() {
+		fmt.Printf("%s took %v\n", name, time.Since(start))
+	}
+}
 func (r *Repository) CreateTable(ctx context.Context, tx *connection.Tx, table *bigqueryv2.Table) error {
 	if err := tx.ContentRepoMode(); err != nil {
 		return err

--- a/internal/metadata/dataset.go
+++ b/internal/metadata/dataset.go
@@ -13,47 +13,11 @@ import (
 var ErrDuplicatedTable = errors.New("table is already created")
 
 type Dataset struct {
-	ID         string
-	ProjectID  string
-	tables     []*Table
-	tableMap   map[string]*Table
-	models     []*Model
-	modelMap   map[string]*Model
-	routines   []*Routine
-	routineMap map[string]*Routine
-	mu         sync.RWMutex
-	content    *bigqueryv2.Dataset
-	repo       *Repository
-}
-
-func (d *Dataset) TableIDs() []string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	tableIDs := make([]string, 0, len(d.tables))
-	for _, table := range d.tables {
-		tableIDs = append(tableIDs, table.ID)
-	}
-	return tableIDs
-}
-
-func (d *Dataset) ModelIDs() []string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	modelIDs := make([]string, 0, len(d.models))
-	for _, model := range d.models {
-		modelIDs = append(modelIDs, model.ID)
-	}
-	return modelIDs
-}
-
-func (d *Dataset) RoutineIDs() []string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	routineIDs := make([]string, 0, len(d.routines))
-	for _, routine := range d.routines {
-		routineIDs = append(routineIDs, routine.ID)
-	}
-	return routineIDs
+	ID        string
+	ProjectID string
+	mu        sync.RWMutex
+	content   *bigqueryv2.Dataset
+	repo      *Repository
 }
 
 func (d *Dataset) Content() *bigqueryv2.Dataset {
@@ -109,25 +73,14 @@ func (d *Dataset) Delete(ctx context.Context, tx *sql.Tx) error {
 }
 
 func (d *Dataset) DeleteModel(ctx context.Context, tx *sql.Tx, id string) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	model, exists := d.modelMap[id]
-	if !exists {
+	model, err := d.repo.FindModel(ctx, d.ProjectID, d.ID, id)
+	if err != nil {
+		return err
+	}
+	if model != nil {
 		return fmt.Errorf("model '%s' is not found in dataset '%s'", id, d.ID)
 	}
 	if err := model.Delete(ctx, tx); err != nil {
-		return err
-	}
-	newModels := make([]*Model, 0, len(d.models))
-	for _, model := range d.models {
-		if model.ID == id {
-			continue
-		}
-		newModels = append(newModels, model)
-	}
-	d.models = newModels
-	delete(d.modelMap, id)
-	if err := d.repo.UpdateDataset(ctx, tx, d); err != nil {
 		return err
 	}
 	return nil
@@ -135,7 +88,11 @@ func (d *Dataset) DeleteModel(ctx context.Context, tx *sql.Tx, id string) error 
 
 func (d *Dataset) AddTable(ctx context.Context, tx *sql.Tx, table *Table) error {
 	d.mu.Lock()
-	if _, exists := d.tableMap[table.ID]; exists {
+	exists, err := d.repo.TableExists(ctx, tx, d.ProjectID, d.ID, table.ID)
+	if err != nil {
+		return err
+	}
+	if exists {
 		d.mu.Unlock()
 		return fmt.Errorf("table %s: %w", table.ID, ErrDuplicatedTable)
 	}
@@ -143,9 +100,6 @@ func (d *Dataset) AddTable(ctx context.Context, tx *sql.Tx, table *Table) error 
 		d.mu.Unlock()
 		return err
 	}
-	d.tables = append(d.tables, table)
-	d.tableMap[table.ID] = table
-	d.mu.Unlock()
 
 	if err := d.repo.UpdateDataset(ctx, tx, d); err != nil {
 		return err
@@ -153,40 +107,28 @@ func (d *Dataset) AddTable(ctx context.Context, tx *sql.Tx, table *Table) error 
 	return nil
 }
 
-func (d *Dataset) Table(id string) *Table {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.tableMap[id]
+func (d *Dataset) Table(ctx context.Context, id string) (*Table, error) {
+	return d.repo.FindTable(ctx, d.ProjectID, d.ID, id)
 }
 
-func (d *Dataset) Model(id string) *Model {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.modelMap[id]
+func (d *Dataset) Model(ctx context.Context, id string) (*Model, error) {
+	return d.repo.FindModel(ctx, d.ProjectID, d.ID, id)
 }
 
-func (d *Dataset) Routine(id string) *Routine {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.routineMap[id]
+func (d *Dataset) Routine(ctx context.Context, id string) (*Routine, error) {
+	return d.repo.FindRoutine(ctx, d.ProjectID, d.ID, id)
 }
 
-func (d *Dataset) Tables() []*Table {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.tables
+func (d *Dataset) Tables(ctx context.Context) ([]*Table, error) {
+	return d.repo.FindTablesInDatasets(ctx, d.ProjectID, d.ID)
 }
 
-func (d *Dataset) Models() []*Model {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.models
+func (d *Dataset) Models(ctx context.Context) ([]*Model, error) {
+	return d.repo.FindModelsInDataset(ctx, d.ProjectID, d.ID)
 }
 
-func (d *Dataset) Routines() []*Routine {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.routines
+func (d *Dataset) Routines(ctx context.Context) ([]*Routine, error) {
+	return d.repo.FindRoutinesInDataset(ctx, d.ProjectID, d.ID)
 }
 
 func NewDataset(
@@ -194,33 +136,12 @@ func NewDataset(
 	projectID string,
 	datasetID string,
 	content *bigqueryv2.Dataset,
-	tables []*Table,
-	models []*Model,
-	routines []*Routine) *Dataset {
-
-	tableMap := map[string]*Table{}
-	for _, table := range tables {
-		tableMap[table.ID] = table
-	}
-	modelMap := map[string]*Model{}
-	for _, model := range models {
-		modelMap[model.ID] = model
-	}
-	routineMap := map[string]*Routine{}
-	for _, routine := range routines {
-		routineMap[routine.ID] = routine
-	}
+) *Dataset {
 
 	return &Dataset{
-		ID:         datasetID,
-		ProjectID:  projectID,
-		tables:     tables,
-		tableMap:   tableMap,
-		models:     models,
-		modelMap:   modelMap,
-		routines:   routines,
-		routineMap: routineMap,
-		content:    content,
-		repo:       repo,
+		ID:        datasetID,
+		ProjectID: projectID,
+		content:   content,
+		repo:      repo,
 	}
 }

--- a/internal/metadata/project.go
+++ b/internal/metadata/project.go
@@ -66,10 +66,14 @@ func (p *Project) FetchJobs(ctx context.Context) ([]*Job, error) {
 }
 
 func (p *Project) Insert(ctx context.Context, tx *sql.Tx) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.repo.AddProject(ctx, tx, p)
 }
 
 func (p *Project) Delete(ctx context.Context, tx *sql.Tx) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.repo.DeleteProject(ctx, tx, p)
 }
 
@@ -83,8 +87,6 @@ func (p *Project) AddDataset(ctx context.Context, tx *sql.Tx, dataset *Dataset) 
 }
 
 func (p *Project) DeleteDataset(ctx context.Context, tx *sql.Tx, id string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	dataset, err := p.Dataset(ctx, id)
 	if err != nil {
 		return err
@@ -92,6 +94,8 @@ func (p *Project) DeleteDataset(ctx context.Context, tx *sql.Tx, id string) erro
 	if dataset == nil {
 		return fmt.Errorf("dataset '%s' is not found in project '%s'", id, p.ID)
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if err := dataset.Delete(ctx, tx); err != nil {
 		return err
 	}
@@ -108,15 +112,15 @@ func (p *Project) AddJob(ctx context.Context, tx *sql.Tx, job *Job) error {
 }
 
 func (p *Project) DeleteJob(ctx context.Context, tx *sql.Tx, id string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	job, err := p.Job(ctx, id)
 	if err != nil {
 		return err
 	}
-	if job != nil {
+	if job == nil {
 		return fmt.Errorf("job '%s' is not found in project '%s'", id, p.ID)
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if err := job.Delete(ctx, tx); err != nil {
 		return err
 	}

--- a/internal/metadata/repository.go
+++ b/internal/metadata/repository.go
@@ -778,6 +778,10 @@ func (r *Repository) FindTablesInDatasets(ctx context.Context, projectID, datase
 		return nil, err
 	}
 	defer tx.Commit()
+	return r.FindTablesInDatasetsWithConnection(ctx, tx, projectID, datasetID)
+}
+
+func (r *Repository) FindTablesInDatasetsWithConnection(ctx context.Context, tx *sql.Tx, projectID, datasetID string) ([]*Table, error) {
 	tablesByDataset, err := r.findTablesInDatasets(ctx, tx, projectID, []string{datasetID})
 	if err != nil {
 		return nil, err

--- a/internal/metadata/repository.go
+++ b/internal/metadata/repository.go
@@ -240,17 +240,7 @@ func (r *Repository) FindProject(ctx context.Context, id string) (*Project, erro
 		return nil, err
 	}
 	defer tx.Commit()
-	projects, err := r.findProjects(ctx, tx, []string{id})
-	if err != nil {
-		return nil, err
-	}
-	if len(projects) != 1 {
-		return nil, nil
-	}
-	if projects[0].ID != id {
-		return nil, nil
-	}
-	return projects[0], nil
+	return r.FindProjectWithConn(ctx, tx, id)
 }
 
 func (r *Repository) findProjects(ctx context.Context, tx *sql.Tx, ids []string) ([]*Project, error) {
@@ -642,6 +632,10 @@ func (r *Repository) FindDataset(ctx context.Context, projectID, datasetID strin
 		return nil, err
 	}
 	defer tx.Commit()
+	return r.FindDatasetWithConnection(ctx, tx, projectID, datasetID)
+}
+
+func (r *Repository) FindDatasetWithConnection(ctx context.Context, tx *sql.Tx, projectID string, datasetID string) (*Dataset, error) {
 	datasets, err := r.findDatasets(ctx, tx, projectID, []string{datasetID})
 	if err != nil {
 		return nil, err
@@ -756,6 +750,10 @@ func (r *Repository) FindTable(ctx context.Context, projectID, datasetID, tableI
 		return nil, err
 	}
 	defer tx.Commit()
+	return r.FindTableWithConnection(ctx, tx, projectID, datasetID, tableID)
+}
+
+func (r *Repository) FindTableWithConnection(ctx context.Context, tx *sql.Tx, projectID, datasetID, tableID string) (*Table, error) {
 	tables, err := r.findTables(ctx, tx, projectID, datasetID, []string{tableID})
 	if err != nil {
 		return nil, err

--- a/internal/prepared_statements.go
+++ b/internal/prepared_statements.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/goccy/go-zetasqlite"
+)
+
+type Statement string
+
+type PreparedStatementBuilder func(ctx context.Context, tx *sql.Tx) (*sql.Stmt, error)
+
+type PreparedStatementRepository struct {
+	preparedQueries map[Statement]*sql.Stmt
+}
+
+func NewPreparedStatementRepository(db *sql.DB, queries []Statement, formattingDisabled bool) *PreparedStatementRepository {
+	var preparedQueries = map[Statement]*sql.Stmt{}
+	ctx := context.Background()
+	if formattingDisabled {
+		ctx = zetasqlite.WithQueryFormattingDisabled(ctx)
+	}
+	for _, query := range queries {
+		stmt, err := db.PrepareContext(ctx, string(query))
+		if err != nil {
+			return nil
+		}
+		preparedQueries[query] = stmt
+	}
+
+	return &PreparedStatementRepository{
+		preparedQueries: preparedQueries,
+	}
+}
+
+func (r *PreparedStatementRepository) Get(ctx context.Context, tx *sql.Tx, name Statement) (*sql.Stmt, error) {
+	if stmt, ok := r.preparedQueries[name]; ok {
+		return tx.StmtContext(ctx, stmt), nil
+	}
+
+	return nil, fmt.Errorf("could not find prepared statement: %s", name)
+}

--- a/internal/prepared_statements.go
+++ b/internal/prepared_statements.go
@@ -15,12 +15,9 @@ type PreparedStatementRepository struct {
 	preparedQueries map[Statement]*sql.Stmt
 }
 
-func NewPreparedStatementRepository(db *sql.DB, queries []Statement, formattingDisabled bool) *PreparedStatementRepository {
+func NewPreparedStatementRepository(db *sql.DB, queries []Statement) *PreparedStatementRepository {
 	var preparedQueries = map[Statement]*sql.Stmt{}
-	ctx := context.Background()
-	if formattingDisabled {
-		ctx = zetasqlite.WithQueryFormattingDisabled(ctx)
-	}
+	ctx := zetasqlite.WithQueryFormattingDisabled(context.Background())
 	for _, query := range queries {
 		stmt, err := db.PrepareContext(ctx, string(query))
 		if err != nil {
@@ -35,6 +32,7 @@ func NewPreparedStatementRepository(db *sql.DB, queries []Statement, formattingD
 }
 
 func (r *PreparedStatementRepository) Get(ctx context.Context, tx *sql.Tx, name Statement) (*sql.Stmt, error) {
+	ctx = zetasqlite.WithQueryFormattingDisabled(ctx)
 	if stmt, ok := r.preparedQueries[name]; ok {
 		return tx.StmtContext(ctx, stmt), nil
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -645,7 +645,7 @@ func (h *datasetsDeleteHandler) Handle(ctx context.Context, r *datasetsDeleteReq
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer tx.RollbackIfNotCommitted()
-	if err := r.project.DeleteDataset(ctx, tx.Tx(), r.dataset.ID); err != nil {
+	if err := r.dataset.Delete(ctx, tx.Tx()); err != nil {
 		return fmt.Errorf("failed to delete dataset: %w", err)
 	}
 	if r.deleteContents {
@@ -654,8 +654,8 @@ func (h *datasetsDeleteHandler) Handle(ctx context.Context, r *datasetsDeleteReq
 			return fmt.Errorf("failed to find tables in dataset: %w", err)
 		}
 		tableIDs := make([]string, len(tables))
-		for _, table := range tables {
-			tableIDs = append(tableIDs, table.ID)
+		for i, table := range tables {
+			tableIDs[i] = table.ID
 			if err := table.Delete(ctx, tx.Tx()); err != nil {
 				return err
 			}
@@ -958,7 +958,7 @@ func (h *jobsDeleteHandler) Handle(ctx context.Context, r *jobsDeleteRequest) er
 		return fmt.Errorf("failed to start transaction: %w", err)
 	}
 	defer tx.RollbackIfNotCommitted()
-	if err := r.project.DeleteJob(ctx, tx.Tx(), r.job.ID); err != nil {
+	if err := r.job.Delete(ctx, tx.Tx()); err != nil {
 		return fmt.Errorf("failed to delete job: %w", err)
 	}
 	if err := tx.Commit(); err != nil {

--- a/server/handler.go
+++ b/server/handler.go
@@ -649,7 +649,7 @@ func (h *datasetsDeleteHandler) Handle(ctx context.Context, r *datasetsDeleteReq
 		return fmt.Errorf("failed to delete dataset: %w", err)
 	}
 	if r.deleteContents {
-		tables, err := r.dataset.Tables(ctx)
+		tables, err := r.server.metaRepo.FindTablesInDatasetsWithConnection(ctx, tx.Tx(), r.dataset.ProjectID, r.dataset.ID)
 		if err != nil {
 			return fmt.Errorf("failed to find tables in dataset: %w", err)
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -327,7 +327,11 @@ func (h *uploadContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	jobID := uploadID[0]
-	job := project.Job(jobID)
+	job, err := project.Job(ctx, jobID)
+	if err != nil {
+		errorResponse(ctx, w, errJobInternalError(err.Error()))
+		return
+	}
 	if err := h.Handle(ctx, &uploadContentRequest{
 		server:  server,
 		project: project,
@@ -401,8 +405,14 @@ func (h *uploadContentHandler) normalizeColumnNameForJSONData(columnMap map[stri
 func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentRequest) error {
 	load := r.job.Content().Configuration.Load
 	tableRef := load.DestinationTable
-	dataset := r.project.Dataset(tableRef.DatasetId)
-	table := dataset.Table(tableRef.TableId)
+	dataset, err := r.project.Dataset(ctx, tableRef.DatasetId)
+	if err != nil {
+		return err
+	}
+	table, err := dataset.Table(ctx, tableRef.TableId)
+	if err != nil {
+		return err
+	}
 	if table == nil {
 		if load.CreateDisposition == "CREATE_NEVER" {
 			return fmt.Errorf("`%s` is not found", tableRef.TableId)
@@ -418,7 +428,10 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 		}); err != nil {
 			return err
 		}
-		table = dataset.Table(tableRef.TableId)
+		table, err = dataset.Table(ctx, tableRef.TableId)
+		if err != nil {
+			return err
+		}
 	}
 
 	tableContent, err := table.Content()
@@ -636,12 +649,19 @@ func (h *datasetsDeleteHandler) Handle(ctx context.Context, r *datasetsDeleteReq
 		return fmt.Errorf("failed to delete dataset: %w", err)
 	}
 	if r.deleteContents {
-		for _, table := range r.dataset.Tables() {
+		tables, err := r.dataset.Tables(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to find tables in dataset: %w", err)
+		}
+		tableIDs := make([]string, len(tables))
+		for _, table := range tables {
+			tableIDs = append(tableIDs, table.ID)
 			if err := table.Delete(ctx, tx.Tx()); err != nil {
 				return err
 			}
 		}
-		if err := r.server.contentRepo.DeleteTables(ctx, tx, r.project.ID, r.dataset.ID, r.dataset.TableIDs()); err != nil {
+
+		if err := r.server.contentRepo.DeleteTables(ctx, tx, r.project.ID, r.dataset.ID, tableIDs); err != nil {
 			return fmt.Errorf("failed to delete tables: %w", err)
 		}
 	}
@@ -736,9 +756,6 @@ func (h *datasetsInsertHandler) Handle(ctx context.Context, r *datasetsInsertReq
 			r.project.ID,
 			datasetID,
 			r.dataset,
-			nil,
-			nil,
-			nil,
 		),
 	); err != nil {
 		return nil, err
@@ -783,7 +800,11 @@ type datasetsListRequest struct {
 
 func (h *datasetsListHandler) Handle(ctx context.Context, r *datasetsListRequest) (*bigqueryv2.DatasetList, error) {
 	datasetsRes := []*bigqueryv2.DatasetListDatasets{}
-	for _, dataset := range r.project.Datasets() {
+	datasets, err := r.server.metaRepo.FindDatasetsInProject(ctx, r.project.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, dataset := range datasets {
 		content := dataset.Content()
 		datasetsRes = append(datasetsRes, &bigqueryv2.DatasetListDatasets{
 			DatasetReference: &bigqueryv2.DatasetReference{
@@ -1449,11 +1470,12 @@ func (h *jobsInsertHandler) Handle(ctx context.Context, r *jobsInsertRequest) (*
 			if err != nil {
 				return nil, err
 			}
-			destinationDataset := r.project.Dataset(tableRef.DatasetId)
-			if destinationDataset == nil {
-				return nil, fmt.Errorf("failed to find destination dataset: %s", tableRef.DatasetId)
+			destinationDataset, err := r.project.Dataset(ctx, tableRef.DatasetId)
+			if destinationDataset == nil || err != nil{
+				return nil, fmt.Errorf("failed to find destination dataset: %s, err: %s", tableRef.DatasetId, err)
 			}
-			destinationTable := destinationDataset.Table(tableRef.TableId)
+			destinationTable, err := destinationDataset.Table(ctx, tableRef.TableId)
+			if err != nil { return nil, fmt.Errorf("failed to query for destination table: %w", err)}
 			destinationTableExists := destinationTable != nil
 			if !destinationTableExists {
 				_, err := createTableMetadata(ctx, tx, r.server, r.project, destinationDataset, tableDef.ToBigqueryV2(r.project.ID, tableRef.DatasetId))
@@ -1559,7 +1581,10 @@ func addTableMetadata(ctx context.Context, server *Server, spec *zetasqlite.Tabl
 	if err != nil {
 		return err
 	}
-	dataset := project.Dataset(datasetID)
+	dataset, err := project.Dataset(ctx, datasetID)
+	if err != nil {
+		return err
+	}
 	if dataset == nil {
 		return fmt.Errorf("dataset %s is not found", datasetID)
 	}
@@ -1607,11 +1632,17 @@ func deleteTableMetadata(ctx context.Context, server *Server, spec *zetasqlite.T
 	if err != nil {
 		return err
 	}
-	dataset := project.Dataset(datasetID)
+	dataset, err := project.Dataset(ctx, datasetID)
+	if err != nil {
+		return err
+	}
 	if dataset == nil {
 		return fmt.Errorf("dataset %s is not found", datasetID)
 	}
-	table := dataset.Table(tableID)
+	table, err := dataset.Table(ctx, tableID)
+	if err != nil {
+		return err
+	}
 	conn, err := server.connMgr.Connection(ctx, projectID, datasetID)
 	if err != nil {
 		return err
@@ -1653,9 +1684,6 @@ func (h *jobsInsertHandler) addQueryResultToDynamicDestinationTable(ctx context.
 				DatasetId: datasetID,
 			},
 		},
-		[]*metadata.Table{table},
-		nil,
-		nil,
 	)
 	if err := r.project.AddDataset(ctx, tx.Tx(), dataset); err != nil {
 		return err
@@ -1693,10 +1721,14 @@ type jobsListRequest struct {
 }
 
 func (h *jobsListHandler) Handle(ctx context.Context, r *jobsListRequest) (*bigqueryv2.JobList, error) {
-	jobs := []*bigqueryv2.JobListJobs{}
-	for _, job := range r.project.Jobs() {
+	jobsList := []*bigqueryv2.JobListJobs{}
+	jobs, err := r.project.FetchJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, job := range jobs {
 		content := job.Content()
-		jobs = append(jobs, &bigqueryv2.JobListJobs{
+		jobsList = append(jobsList, &bigqueryv2.JobListJobs{
 			Id:           content.Id,
 			JobReference: content.JobReference,
 			Kind:         content.Kind,
@@ -1705,7 +1737,7 @@ func (h *jobsListHandler) Handle(ctx context.Context, r *jobsListRequest) (*bigq
 			UserEmail:    content.UserEmail,
 		})
 	}
-	return &bigqueryv2.JobList{Jobs: jobs}, nil
+	return &bigqueryv2.JobList{Jobs: jobsList}, nil
 }
 
 func (h *jobsQueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -1900,13 +1932,17 @@ type modelsListRequest struct {
 }
 
 func (h *modelsListHandler) Handle(ctx context.Context, r *modelsListRequest) (*bigqueryv2.ListModelsResponse, error) {
-	models := []*bigqueryv2.Model{}
-	for _, m := range r.dataset.Models() {
+	response := []*bigqueryv2.Model{}
+	models, err := r.dataset.Models(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range models {
 		_ = m
-		models = append(models, &bigqueryv2.Model{})
+		response = append(response, &bigqueryv2.Model{})
 	}
 	return &bigqueryv2.ListModelsResponse{
-		Models: models,
+		Models: response,
 	}, nil
 }
 
@@ -2129,13 +2165,17 @@ type routinesListRequest struct {
 }
 
 func (h *routinesListHandler) Handle(ctx context.Context, r *routinesListRequest) (*bigqueryv2.ListRoutinesResponse, error) {
-	var routineList []*bigqueryv2.Routine
-	for _, routine := range r.dataset.Routines() {
+	var response []*bigqueryv2.Routine
+	routines, err := r.dataset.Routines(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, routine := range routines {
 		_ = routine
-		routineList = append(routineList, &bigqueryv2.Routine{})
+		response = append(response, &bigqueryv2.Routine{})
 	}
 	return &bigqueryv2.ListRoutinesResponse{
-		Routines: routineList,
+		Routines: response,
 	}, fmt.Errorf("unsupported bigquery.routines.list")
 }
 
@@ -2549,14 +2589,16 @@ func (h *tablesGetIamPolicyHandler) Handle(ctx context.Context, r *tablesGetIamP
 
 func (h *tablesInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	server := serverFromContext(ctx)
-	project := projectFromContext(ctx)
-	dataset := datasetFromContext(ctx)
+
 	var table bigqueryv2.Table
 	if err := json.NewDecoder(r.Body).Decode(&table); err != nil {
 		errorResponse(ctx, w, errInvalid(err.Error()))
 		return
 	}
+
+	server := serverFromContext(ctx)
+	project := projectFromContext(ctx)
+	dataset := datasetFromContext(ctx)
 	res, err := h.Handle(ctx, &tablesInsertRequest{
 		server:  server,
 		project: project,
@@ -2686,28 +2728,32 @@ type tablesListRequest struct {
 }
 
 func (h *tablesListHandler) Handle(ctx context.Context, r *tablesListRequest) (*bigqueryv2.TableList, error) {
-	var tables []*bigqueryv2.TableListTables
-	for _, tableID := range r.dataset.TableIDs() {
-		table, err := r.dataset.Table(tableID).Content()
+	var response []*bigqueryv2.TableListTables
+	tables, err := r.dataset.Tables(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find tables in dataset: %w", err)
+	}
+	for _, table := range tables {
+		content, err := table.Content()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get table metadata from %s: %w", tableID, err)
+			return nil, fmt.Errorf("failed to get table metadata from %s: %w", table.ID, err)
 		}
-		tables = append(tables, &bigqueryv2.TableListTables{
-			Clustering:        table.Clustering,
-			CreationTime:      table.CreationTime,
-			ExpirationTime:    table.ExpirationTime,
-			FriendlyName:      table.FriendlyName,
-			Id:                table.Id,
-			Kind:              table.Kind,
-			Labels:            table.Labels,
-			RangePartitioning: table.RangePartitioning,
-			TableReference:    table.TableReference,
-			TimePartitioning:  table.TimePartitioning,
-			Type:              table.Type,
+		response = append(response, &bigqueryv2.TableListTables{
+			Clustering:        content.Clustering,
+			CreationTime:      content.CreationTime,
+			ExpirationTime:    content.ExpirationTime,
+			FriendlyName:      content.FriendlyName,
+			Id:                content.Id,
+			Kind:              content.Kind,
+			Labels:            content.Labels,
+			RangePartitioning: content.RangePartitioning,
+			TableReference:    content.TableReference,
+			TimePartitioning:  content.TimePartitioning,
+			Type:              content.Type,
 		})
 	}
 	return &bigqueryv2.TableList{
-		Tables:     tables,
+		Tables:     response,
 		TotalItems: int64(len(tables)),
 	}, nil
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -285,7 +285,7 @@ func withModelMiddleware() func(http.Handler) http.Handler {
 				dataset := datasetFromContext(ctx)
 				model, err := dataset.Model(ctx, modelID)
 				if err != nil {
-					errorResponse(ctx, w, errInternalError(fmt.Sprint("failed to find model: %s", err)))
+					errorResponse(ctx, w, errInternalError(fmt.Sprintf("failed to find model: %s", err)))
 					return
 				}
 				if model == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,9 @@ func New(storage Storage) (*Server, error) {
 		}
 	}
 	db, err := sql.Open("zetasqlite", string(storage))
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxIdleTime(-1)
+	db.SetConnMaxLifetime(1<<63 - 1)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +132,7 @@ func (s *Server) SetProject(id string) error {
 	if err := s.metaRepo.AddProjectIfNotExists(
 		ctx,
 		tx.Tx(),
-		metadata.NewProject(s.metaRepo, id, nil, nil),
+		metadata.NewProject(s.metaRepo, id),
 	); err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -48,7 +48,6 @@ func New(storage Storage) (*Server, error) {
 		}
 	}
 	db, err := sql.Open("zetasqlite", string(storage))
-	db.SetMaxIdleConns(1)
 	db.SetConnMaxIdleTime(-1)
 	db.SetConnMaxLifetime(1<<63 - 1)
 	if err != nil {

--- a/server/storage_handler.go
+++ b/server/storage_handler.go
@@ -805,11 +805,17 @@ func getTableMetadata(ctx context.Context, server *Server, projectID, datasetID,
 	if err != nil {
 		return nil, err
 	}
-	dataset := project.Dataset(datasetID)
+	dataset, err := project.Dataset(ctx, datasetID)
+	if err != nil {
+		return nil, err
+	}
 	if dataset == nil {
 		return nil, fmt.Errorf("dataset %s is not found in project %s", datasetID, projectID)
 	}
-	table := dataset.Table(tableID)
+	table, err := dataset.Table(ctx, tableID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find table %s: %w", tableID, err)
+	}
 	if table == nil {
 		return nil, fmt.Errorf("table %s is not found in dataset %s", tableID, datasetID)
 	}


### PR DESCRIPTION
This PR greatly improves the performance of the emulator API endpoints.

We no longer load the entire BigQuery project (jobs, datasets, tables, etc) on each request. This was slow for a number of reasons as outlined in goccy/bigquery-emulator#294

We also now utilize unformatted SQLite queries. Previously, `go-zetasqlite` would rewrite the metadata repository queries to use functions like `zetasqlite_equals` instead of operators like `=`, which meant that SQLite would need to do full table scans when it could be doing more performant query plans.

Many endpoints now take tens of microseconds to return instead of 100+ms. Table creation takes roughly ~10ms whereas before we were seeing upwards of 300ms.

```
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs   {"query": "prettyPrint=false"}
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs took 16.821342ms
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views       {"query": "prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views took 287.595µs
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs   {"query": "prettyPrint=false"}
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs took 19.376201ms
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/c0150a30-f7c6-4bbf-b9e3-a00dd494f14d    {"query": "maxResults=0&location=US&prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/c0150a30-f7c6-4bbf-b9e3-a00dd494f14d took 791.9µs
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/d1e45499-8eb2-4417-bf5d-af0c1266503a    {"query": "maxResults=0&location=US&prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/d1e45499-8eb2-4417-bf5d-af0c1266503a took 645.539µs
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/outliers_staff_count_percent_change_materialized       {"query": "prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/outliers_staff_count_percent_change_materialized took 1.660463ms
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/current_supervision_staff_missing_district_materialized        {"query": "prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/current_supervision_staff_missing_district_materialized took 1.354469ms
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables       {"query": "prettyPrint=false"}
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables took 13.399834ms
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views       {"query": "prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views took 298.365µs
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs   {"query": "prettyPrint=false"}
POST /bigquery/v2/projects/recidiviz-bq-emulator-project/jobs took 16.414274ms
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/55f3fc1a-05c2-41a5-88dd-0f9f592f4a1c    {"query": "maxResults=0&location=US&prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/queries/55f3fc1a-05c2-41a5-88dd-0f9f592f4a1c took 458.882µs
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/outliers_staff_count_percent_change_errors_materialized        {"query": "prettyPrint=false"}
GET /bigquery/v2/projects/recidiviz-bq-emulator-project/datasets/validation_views/tables/outliers_staff_count_percent_change_errors_materialized took 1.560456ms
```

We are now able to do a run of  `recidiviz.tools.deploy.deploy_empty_test_views` creating & materializing 1,400 views 
 against the emulator in ~35 seconds.