### PR TITLE
Return `invalidQuery` to avoid Python SDK's default 10-minute retry for `internalError` responses

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -1065,7 +1065,7 @@ func (h *jobsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		job:     &job,
 	})
 	if err != nil {
-		errorResponse(ctx, w, errJobInternalError(err.Error()))
+		errorResponse(ctx, w, errInvalidQuery(err.Error()))
 		return
 	}
 	encodeResponse(ctx, w, res)
@@ -1758,7 +1758,7 @@ func (h *jobsQueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		useInt64Timestamp: isFormatOptionsUseInt64Timestamp(r),
 	})
 	if err != nil {
-		errorResponse(ctx, w, errJobInternalError(err.Error()))
+		errorResponse(ctx, w, errInvalidQuery(err.Error()))
 		return
 	}
 	encodeResponse(ctx, w, res)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,6 +114,18 @@ func TestSimpleQuery(t *testing.T) {
 		}
 		if len(row) != 1 || row[0] == nil {
 			t.Fatal("Failed to query null ARRAY")
+		}
+	})
+
+	// Regression test for goccy/bigquery-emulator#316
+	t.Run("invalid query", func(t *testing.T) {
+		query := client.Query("SELECT!;")
+		_, err := query.Read(ctx)
+		if err == nil {
+			t.Fatal("Expected error, but got nil")
+		}
+		if !strings.HasSuffix(err.Error(), "invalidQuery") {
+			t.Fatal("expected invalid query")
 		}
 	})
 }


### PR DESCRIPTION
goccy/bigquery-emulator#312