### PR TITLE
Allow DROP VIEW and DROP MATERIALIZED VIEW

### DIFF
--- a/_examples/python/table_and_view.py
+++ b/_examples/python/table_and_view.py
@@ -1,0 +1,62 @@
+"""
+This example creates a dataset, table, and view,
+shows that the output of the table and view are expected,
+and removes the dataset, table, and view.
+"""
+
+from google.api_core.client_options import ClientOptions
+from google.auth.credentials import AnonymousCredentials
+from google.cloud import bigquery
+
+if __name__ == "__main__":
+    client_options = ClientOptions(api_endpoint="http://0.0.0.0:9050")
+    client = bigquery.Client(
+        "test",
+        client_options=client_options,
+        credentials=AnonymousCredentials(),
+    )
+
+    client.create_dataset("example_dataset")
+
+    print("Setting up table")
+    example_table = client.create_table(
+        bigquery.Table(
+            "test.example_dataset.example_table",
+            [
+                bigquery.SchemaField("string_field", "STRING"),
+            ],
+        )
+    )
+    print("Loading table")
+    rows_to_insert = [
+        {"string_field": "An example string"},
+        {"string_field": "Hello, BigQuery!"},
+    ]
+    _ = client.insert_rows_json("test.example_dataset.example_table", rows_to_insert)
+
+    print("Setting up view")
+    _view_definition = bigquery.Table("test.example_dataset.example_view")
+    _view_definition.view_query = "SELECT * FROM `test.example_dataset.example_table`"
+    example_view = client.create_table(_view_definition)
+
+    print("Running queries")
+    table_data = list(
+        client.query(
+            query="SELECT * FROM example_dataset.example_table",
+            job_config=bigquery.QueryJobConfig(),
+        )
+    )
+
+    view_data = list(
+        client.query(
+            query="SELECT * FROM example_dataset.example_view",
+            job_config=bigquery.QueryJobConfig(),
+        )
+    )
+
+    assert table_data == view_data
+
+    print("Cleaning up tables")
+    client.delete_table(example_view)
+    client.delete_table(example_table)
+    client.delete_dataset("example_dataset")

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/goccy/bigquery-emulator/internal/connection"
 	"github.com/goccy/bigquery-emulator/internal/logger"
+	"github.com/goccy/bigquery-emulator/internal/metadata"
 	internaltypes "github.com/goccy/bigquery-emulator/internal/types"
 	"github.com/goccy/bigquery-emulator/types"
 )
@@ -428,7 +429,7 @@ func (r *Repository) AddTableData(ctx context.Context, tx *connection.Tx, projec
 	return nil
 }
 
-func (r *Repository) DeleteTables(ctx context.Context, tx *connection.Tx, projectID, datasetID string, tableIDs []string) error {
+func (r *Repository) DeleteTables(ctx context.Context, tx *connection.Tx, projectID, datasetID string, tables []*metadata.Table) error {
 	tx.SetProjectAndDataset(projectID, datasetID)
 	if err := tx.ContentRepoMode(); err != nil {
 		return err
@@ -437,10 +438,22 @@ func (r *Repository) DeleteTables(ctx context.Context, tx *connection.Tx, projec
 		_ = tx.MetadataRepoMode()
 	}()
 
-	for _, tableID := range tableIDs {
-		tablePath := r.tablePath(projectID, datasetID, tableID)
+	for _, table := range tables {
+		tablePath := r.tablePath(projectID, datasetID, table.ID)
 		logger.Logger(ctx).Debug("delete table", zap.String("table", tablePath))
-		query := fmt.Sprintf("DROP TABLE `%s`", tablePath)
+		tableContent, err := table.Content()
+		if err != nil {
+			return fmt.Errorf("failed to delete table %s: %w", tablePath, err)
+		}
+		var query string
+		switch tableContent.Type {
+		case string(internaltypes.MaterializedViewTableType):
+			query = fmt.Sprintf("DROP MATERIALIZED VIEW `%s`", tablePath)
+		case string(internaltypes.DefaultTableType), string(internaltypes.ViewTableType):
+			query = fmt.Sprintf("DROP %s `%s`", tableContent.Type, tablePath)
+		default:
+			return fmt.Errorf("failed to delete table with unsupported table type: %s", tableContent.Type)
+		}
 		if _, err := tx.Tx().ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to delete table %s: %w", query, err)
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -10,6 +10,16 @@ import (
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
 )
 
+type TableType string
+
+const (
+	DefaultTableType          TableType = "TABLE"
+	ViewTableType             TableType = "VIEW"
+	ExternalTableType         TableType = "EXTERNAL"
+	MaterializedViewTableType TableType = "MATERIALIZED_VIEW"
+	SnapshotTableType         TableType = "SNAPSHOT"
+)
+
 type (
 	GetQueryResultsResponse struct {
 		JobReference *bigqueryv2.JobReference `json:"jobReference"`


### PR DESCRIPTION
The `DeleteTables` function was only dropping tables, despite the rest of the project being aware of all BigQuery table types. This PR moves those table types to `internal/types` to be used more easily, and then checks for the table type when dropping a table.

@ohaibbq I had made a different candidate branch `candidate/rb20240815`, but saw that our fork of this repo and go-zetasqlite have some mismatch with goccy's when I rebased it (both ours and his have quite a few changes). Do you think it would be easier to get our forks in sync before getting this change in? (I'm not sure what the upstream response time is). 

This change would unblock a few issues for us, so I'd be happy to make a new release for us with this change and then spend some time contributing to syncing with goccy when I am back from PTO.