### PR TITLE
Upgrade `go-sqlite3` to `candidate/rb20250123`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/linkedin/goavro/v2 v2.12.0
+	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/segmentio/parquet-go v0.0.0-20221020201645-63215c8128ff
 	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.3.0
@@ -62,7 +63,6 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
@@ -91,4 +91,4 @@ require (
 
 replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.11
 
-replace github.com/mattn/go-sqlite3 => github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048
+replace github.com/mattn/go-sqlite3 => github.com/Recidiviz/go-sqlite3 v0.0.0-20250123175831-0a6c44992ce2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/GoogleCloudPlatform/golang-samples/bigquery v0.0.0-20221115172052-07f
 github.com/GoogleCloudPlatform/golang-samples/bigquery v0.0.0-20221115172052-07ffb99455e8/go.mod h1:VB6n8DYUiQ07iCBJ5MTjHy8+zI5FNiNT0IDbZ00nhAc=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
-github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048 h1:G8qFbNf/6IWYup4//DcrwsMYvAl80qZk9hEb6Z+UfKc=
-github.com/Recidiviz/go-sqlite3 v0.0.0-20240220230115-bffb5ad78048/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/Recidiviz/go-sqlite3 v0.0.0-20250123175831-0a6c44992ce2 h1:o4YxmZH/Ln6CoPL9s7gHKmrBqI2vxirPs6ZVpL5yWNc=
+github.com/Recidiviz/go-sqlite3 v0.0.0-20250123175831-0a6c44992ce2/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.11 h1:jmzPWrrOQJREO0BCNcY6eqmfwKSB1rDQcfomWUJXr3g=
 github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.11/go.mod h1:KVfVr9Lp7/4FH0Eeiunu1Dh274lxKJvWwpQWEkoRkuA=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=


### PR DESCRIPTION
@ageiduschek was running into a `too many arguments on function zetasqlite_or` error. This was caused by the limits of SQLite3. SQLite allows you to change these limits at runtime by calling the [`sqlite3_limit` function](https://github.com/Recidiviz/go-zetasqlite/blob/candidate/rb20240116/driver.go#L33), but enforces a hard limit of 127 for function arguments.

I've updated the `sqlite3` amalgamation code to `3.48.0` [which raised the default limit to 1,000.](https://github.com/sqlite/sqlite/blob/726a047a4767ebde16b64a807ca4d9132aa39a5e/src/sqliteLimit.h#L91-L99)
However, in doing so, it also broke the test suite of `go-sqlite3` since the [User Authentication module was removed and deprecated in 3.48](https://github.com/sqlite/sqlite/commit/bc4df6079c654b52786de49d7ad17ca30ac9822b)

I've documented this here- https://github.com/mattn/go-sqlite3/issues/1268#issuecomment-2610613926