### PR TITLE
Bump `go-zetasqlite` to `v0.18.0-recidiviz.13`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,4 +98,4 @@ require (
 	modernc.org/memory v1.9.1 // indirect
 )
 
-replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.12.2
+replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.13

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/GoogleCloudPlatform/golang-samples/bigquery v0.0.0-20221115172052-07f
 github.com/GoogleCloudPlatform/golang-samples/bigquery v0.0.0-20221115172052-07ffb99455e8/go.mod h1:VB6n8DYUiQ07iCBJ5MTjHy8+zI5FNiNT0IDbZ00nhAc=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.12.2 h1:p/UdVzLOi7g85slDH5FhdP2r8Ge283yBXPqbVe4K+y0=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.12.2/go.mod h1:Agt3iLNpF7Ct4aXDflKYGt+mvzECaRfIPDTPyYCWz8c=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.13 h1:jnTGSOZ5ZAc3hoC6zHiBJxJYAVOe42Hb7UmKGsKt1CI=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.13/go.mod h1:Agt3iLNpF7Ct4aXDflKYGt+mvzECaRfIPDTPyYCWz8c=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=


### PR DESCRIPTION
Includes a fix from Recidiviz/go-zetasqlite#52