### PR TITLE
Fix crash when running on arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             artifact_name: bigquery-emulator
             asset_name: bigquery-emulator-linux-amd64
             platform: linux/amd64
-          - runner: runs-on=${{github.run_id}}/runner=4cpu-linux-arm64
+          - runner: ubuntu-24.04-arm
             artifact_name: bigquery-emulator
             asset_name: bigquery-emulator-linux-arm64
             platform: linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG VERSION
 
 WORKDIR /work
 
+RUN apt update && apt install -y lld && rm -rf /var/lib/apt/lists/*
+
 COPY . ./
 
 RUN go mod edit -replace github.com/goccy/go-zetasql=../go-zetasql

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG VERSION
 
 WORKDIR /work
 
-RUN apt update && apt install -y lld && rm -rf /var/lib/apt/lists/*
-
 COPY . ./
 
 RUN go mod edit -replace github.com/goccy/go-zetasql=../go-zetasql
@@ -13,7 +11,8 @@ RUN go mod download
 
 RUN make emulator/build
 
-FROM debian:bullseye AS emulator
+# Since the binary uses dynamic linking we must use the same base image as the build runtime
+FROM ghcr.io/recidiviz/go-zetasql:0.5.5-recidiviz.3 AS emulator
 
 COPY --from=0 /work/bigquery-emulator /bin/bigquery-emulator
 

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ UNAME_OS := $(shell uname -s)
 UNAME_ARCH := $(shell uname -m)
 ifeq ($(UNAME_OS),Linux)
   ifeq ($(UNAME_ARCH),aarch64)
-    STATIC_LINK_FLAG := -linkmode external -extldflags "-static -fPIE -v"
+    STATIC_LINK_FLAG := -v -linkmode external -extldflags "-static -fPIC -v"
   else
     STATIC_LINK_FLAG := -linkmode external -extldflags "-static -v"
   endif
 endif
 
 emulator/build:
-	CGO_ENABLED=1 CXX=clang++ CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
+	CGO_ENABLED=1 CXX=clang++ CGO_LDFLAGS="-fuse-ld=lld" CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
 		-ldflags='${STATIC_LINK_FLAG}' \
 		./cmd/bigquery-emulator
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ VERSION ?= latest
 REVISION := $(shell git rev-parse --short HEAD)
 
 emulator/build:
-	CGO_ENABLED=1 CXX=clang++ CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
-		-ldflags='${STATIC_LINK_FLAG}' \
+	CGO_ENABLED=1 CXX=clang++ go build -o bigquery-emulator \
 		./cmd/bigquery-emulator
 
 docker/build:

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,8 @@
 VERSION ?= latest
 REVISION := $(shell git rev-parse --short HEAD)
 
-UNAME_OS := $(shell uname -s)
-UNAME_ARCH := $(shell uname -m)
-ifeq ($(UNAME_OS),Linux)
-  ifeq ($(UNAME_ARCH),aarch64)
-    STATIC_LINK_FLAG := -v -linkmode external -extldflags "-static -fPIC -v"
-  else
-    STATIC_LINK_FLAG := -linkmode external -extldflags "-static -v"
-  endif
-endif
-
 emulator/build:
-	CGO_ENABLED=1 CXX=clang++ CGO_LDFLAGS="-fuse-ld=lld" CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
+	CGO_ENABLED=1 CXX=clang++ CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
 		-ldflags='${STATIC_LINK_FLAG}' \
 		./cmd/bigquery-emulator
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(UNAME_OS),Linux)
 endif
 
 emulator/build:
-	CGO_ENABLED=1 CXX=clang++ CGO_CFLAGS="-fPIE" CGO_CXXFLAGS="-fPIE" go build -work -a -x -o bigquery-emulator \
+	CGO_ENABLED=1 CXX=clang++ CGO_CFLAGS="-fPIC" CGO_CXXFLAGS="-fPIC" go build -work -a -x -o bigquery-emulator \
 		-ldflags='${STATIC_LINK_FLAG}' \
 		./cmd/bigquery-emulator
 


### PR DESCRIPTION
The previous binary was built using the `-fPIE` (position-independent executable). We were seeing requests to the emulator fail with EOF errors (particularly during the parsing of json). Instead of using `-fPIE`, this PR switches to using dynamic linking which removes the need for the `-fPIE` flag on arm64.

> `-fPIE` can cause runtime issues, especially with CGO and static linking.
The Issue with `-fPIE`
PIE (Position Independent Executable) changes how the binary is loaded and how symbols are resolved at runtime. With static linking + CGO + complex C++ libraries like ZetaSQL, this can cause:
>* Symbol resolution issues - CGO symbols may not resolve correctly
>* Memory layout problems - Static libraries expect fixed addresses
>* Dynamic loading conflicts - Your error log showed dlopen warnings