### PR TITLE
Quote record fieldnames when creating a table

### DIFF
--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -155,7 +155,7 @@ func (r *Repository) encodeSchemaField(field *bigqueryv2.TableFieldSchema) strin
 	if field.Type == "RECORD" {
 		types := make([]string, 0, len(field.Fields))
 		for _, f := range field.Fields {
-			types = append(types, fmt.Sprintf("%s %s", f.Name, r.encodeSchemaField(f)))
+			types = append(types, fmt.Sprintf("`%s` %s", f.Name, r.encodeSchemaField(f)))
 		}
 		elem = fmt.Sprintf("STRUCT<%s>", strings.Join(types, ","))
 	} else {


### PR DESCRIPTION
- When handling a RECORD column during table creation we were missing a
  backtick around the field name. This caused problems if the filed name
  was a reserved word (e.g. 'current') in BigQuery SQL.