### PR TITLE
Add support for CSV upload with type detection

### DIFF
--- a/server/csv_autodetect_test.go
+++ b/server/csv_autodetect_test.go
@@ -43,6 +43,10 @@ func TestIsBool(t *testing.T) {
 		{"TRUE", true},
 		{"FALSE", true},
 		{"True", true},
+		{"t", true},
+		{"f", true},
+		{"T", true},
+		{"F", true},
 		{"yes", true},
 		{"no", true},
 		{"YES", true},
@@ -51,8 +55,9 @@ func TestIsBool(t *testing.T) {
 		{"n", true},
 		{"Y", true},
 		{"N", true},
-		{"1", true},
-		{"0", true},
+		// 1/0 are NOT auto-detected as boolean (BigQuery behavior)
+		{"1", false},
+		{"0", false},
 		{"", false},
 		{"maybe", false},
 		{"2", false},
@@ -125,64 +130,137 @@ func TestIsFloat(t *testing.T) {
 	}
 }
 
-func TestDetectDateFormat(t *testing.T) {
+func TestIsDate(t *testing.T) {
 	testCases := []struct {
-		name           string
-		values         []string
-		expectedLayout string
+		input    string
+		expected bool
 	}{
-		{
-			name:           "iso_format",
-			values:         []string{"2024-01-15", "2024-12-31"},
-			expectedLayout: "2006-01-02",
-		},
-		{
-			name:           "uk_format_unambiguous",
-			values:         []string{"15/01/2024", "25/12/2024"},
-			expectedLayout: "02/01/2006",
-		},
-		{
-			name:           "us_format_unambiguous",
-			values:         []string{"01/15/2024", "12/25/2024"},
-			expectedLayout: "01/02/2006",
-		},
-		{
-			name:           "uk_dash_format",
-			values:         []string{"15-01-2024", "25-12-2024"},
-			expectedLayout: "02-01-2006",
-		},
-		{
-			name:           "ambiguous_defaults_to_iso",
-			values:         []string{"2024-01-05"},
-			expectedLayout: "2006-01-02",
-		},
-		{
-			name:           "ambiguous_slash_defaults_to_uk",
-			values:         []string{"01/02/2024"},
-			expectedLayout: "02/01/2006", // UK is preferred over US when ambiguous
-		},
-		{
-			name:           "not_a_date",
-			values:         []string{"hello", "world"},
-			expectedLayout: "",
-		},
-		{
-			name:           "empty_values",
-			values:         []string{},
-			expectedLayout: "",
-		},
-		{
-			name:           "mixed_valid_invalid",
-			values:         []string{"2024-01-15", "not-a-date"},
-			expectedLayout: "",
-		},
+		// Valid ISO dates
+		{"2024-01-15", true},
+		{"2024-12-31", true},
+		{"2000-01-01", true},
+		{"  2024-01-15  ", true}, // Whitespace trimmed
+		// Invalid formats (UK/US not supported by BigQuery)
+		{"15/01/2024", false},
+		{"01/15/2024", false},
+		{"15-01-2024", false},
+		{"01-15-2024", false},
+		// Invalid values
+		{"not-a-date", false},
+		{"", false},
+		{"2024/01/15", false}, // Slash separator not valid for DATE
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := detectDateFormat(tc.values)
-			if result != tc.expectedLayout {
-				t.Errorf("detectDateFormat(%v) = %q, want %q", tc.values, result, tc.expectedLayout)
+		t.Run(tc.input, func(t *testing.T) {
+			result := isDate(tc.input)
+			if result != tc.expected {
+				t.Errorf("isDate(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsTime(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		// Valid times
+		{"10:30:00", true},
+		{"10:30:00.123456", true},
+		{"10:30:00.123", true},
+		{"23:59:59", true},
+		{"00:00:00", true},
+		{"  14:30:00  ", true}, // Whitespace trimmed
+		// Invalid times
+		{"10:30", false},     // Missing seconds
+		{"25:00:00", false},  // Invalid hour
+		{"10:60:00", false},  // Invalid minute
+		{"10:30:00Z", false}, // Has timezone - not TIME
+		{"hello", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isTime(tc.input)
+			if result != tc.expected {
+				t.Errorf("isTime(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsDatetime(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		// Valid datetimes
+		{"2024-01-15 10:30:00", true},
+		{"2024-01-15 10:30:00.123456", true},
+		{"2024-01-15T10:30:00", true},
+		{"2024-01-15T10:30:00.123456", true},
+		{"  2024-01-15 10:30:00  ", true}, // Whitespace trimmed
+		// Invalid - has timezone (should be TIMESTAMP)
+		{"2024-01-15 10:30:00Z", false},
+		{"2024-01-15 10:30:00 UTC", false},
+		{"2024-01-15 10:30:00-05:00", false},
+		{"2024-01-15T10:30:00Z", false},
+		// Invalid - not a datetime
+		{"2024-01-15", false}, // No time - DATE
+		{"10:30:00", false},   // No date - TIME
+		{"hello", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isDatetime(tc.input)
+			if result != tc.expected {
+				t.Errorf("isDatetime(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsTimestamp(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		// With Z suffix
+		{"2024-01-15T10:30:00Z", true},
+		{"2024-01-15T10:30:00.123456Z", true},
+		{"2024-01-15 10:30:00Z", true},
+		// With UTC
+		{"2024-01-15 10:30:00 UTC", true},
+		// With offset
+		{"2024-01-15T10:30:00-05:00", true},
+		{"2024-01-15 10:30:00 -05:00", true},
+		{"2024-01-15 10:30:00.220 -05:00", true},
+		// Slash date format
+		{"2018/08/19 12:11", true},
+		{"2018/08/19 12:11:35", true},
+		{"2018/08/19 12:11:35.22", true},
+		// Unix epoch is NOT auto-detected per BigQuery docs
+		{"1534680695", false},
+		{"1.534680695e12", false},
+		// Invalid cases
+		{"2024-01-15 10:30:00", false}, // No timezone - DATETIME
+		{"2024-01-15", false},          // No time - DATE
+		{"hello", false},
+		{"", false},
+		{"123", false},
+		{"0", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isTimestamp(tc.input)
+			if result != tc.expected {
+				t.Errorf("isTimestamp(%q) = %v, want %v", tc.input, result, tc.expected)
 			}
 		})
 	}
@@ -208,10 +286,22 @@ func TestInferFieldType(t *testing.T) {
 			expectedType: "BOOL",
 		},
 		{
+			name:         "bool_t_f",
+			rows:         [][]string{{"t"}, {"f"}, {"T"}},
+			colIndex:     0,
+			expectedType: "BOOL",
+		},
+		{
 			name:         "integer",
 			rows:         [][]string{{"1"}, {"42"}, {"-100"}},
 			colIndex:     0,
 			expectedType: "INTEGER",
+		},
+		{
+			name:         "integer_zero_one_not_bool",
+			rows:         [][]string{{"0"}, {"1"}, {"0"}},
+			colIndex:     0,
+			expectedType: "INTEGER", // Changed: 0/1 are not auto-detected as BOOL
 		},
 		{
 			name:         "float",
@@ -226,10 +316,52 @@ func TestInferFieldType(t *testing.T) {
 			expectedType: "DATE",
 		},
 		{
-			name:         "date_uk",
+			name:         "date_uk_now_string",
 			rows:         [][]string{{"15/01/2024"}, {"31/12/2024"}},
 			colIndex:     0,
-			expectedType: "DATE",
+			expectedType: "STRING", // Changed: UK format not supported
+		},
+		{
+			name:         "time",
+			rows:         [][]string{{"10:30:00"}, {"14:45:30.123456"}},
+			colIndex:     0,
+			expectedType: "TIME",
+		},
+		{
+			name:         "datetime",
+			rows:         [][]string{{"2024-01-15 10:30:00"}, {"2024-12-31 23:59:59"}},
+			colIndex:     0,
+			expectedType: "DATETIME",
+		},
+		{
+			name:         "datetime_with_t",
+			rows:         [][]string{{"2024-01-15T10:30:00"}, {"2024-12-31T23:59:59"}},
+			colIndex:     0,
+			expectedType: "DATETIME",
+		},
+		{
+			name:         "timestamp_with_z",
+			rows:         [][]string{{"2024-01-15T10:30:00Z"}, {"2024-12-31T23:59:59Z"}},
+			colIndex:     0,
+			expectedType: "TIMESTAMP",
+		},
+		{
+			name:         "timestamp_with_offset",
+			rows:         [][]string{{"2024-01-15 10:30:00-05:00"}, {"2024-12-31 23:59:59+00:00"}},
+			colIndex:     0,
+			expectedType: "TIMESTAMP",
+		},
+		{
+			name:         "timestamp_slash_date",
+			rows:         [][]string{{"2018/08/19 12:11:35"}, {"2018/08/20 14:30:00"}},
+			colIndex:     0,
+			expectedType: "TIMESTAMP",
+		},
+		{
+			name:         "unix_epoch_is_integer",
+			rows:         [][]string{{"1534680695"}, {"1534680700"}},
+			colIndex:     0,
+			expectedType: "INTEGER", // Unix timestamps are NOT auto-detected per BigQuery docs
 		},
 		{
 			name:         "string",
@@ -404,17 +536,59 @@ func TestConvertCSVValue(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "date_uk_to_iso",
+			name:     "date_uk_now_error",
 			value:    "15/01/2024",
 			colType:  types.DATE,
-			expected: "2024-01-15",
+			expected: nil,
+			wantErr:  true, // UK format not supported
+		},
+		{
+			name:     "date_us_now_error",
+			value:    "01/15/2024",
+			colType:  types.DATE,
+			expected: nil,
+			wantErr:  true, // US format not supported
+		},
+		{
+			name:     "time",
+			value:    "10:30:00",
+			colType:  types.TIME,
+			expected: "10:30:00.000000",
 			wantErr:  false,
 		},
 		{
-			name:     "date_us_to_iso",
-			value:    "01/15/2024",
-			colType:  types.DATE,
-			expected: "2024-01-15",
+			name:     "time_with_microseconds",
+			value:    "10:30:00.123456",
+			colType:  types.TIME,
+			expected: "10:30:00.123456",
+			wantErr:  false,
+		},
+		{
+			name:     "datetime",
+			value:    "2024-01-15 10:30:00",
+			colType:  types.DATETIME,
+			expected: "2024-01-15 10:30:00.000000",
+			wantErr:  false,
+		},
+		{
+			name:     "datetime_with_t",
+			value:    "2024-01-15T10:30:00",
+			colType:  types.DATETIME,
+			expected: "2024-01-15 10:30:00.000000",
+			wantErr:  false,
+		},
+		{
+			name:     "timestamp_z",
+			value:    "2024-01-15T10:30:00Z",
+			colType:  types.TIMESTAMP,
+			expected: "2024-01-15T10:30:00Z",
+			wantErr:  false,
+		},
+		{
+			name:     "timestamp_offset",
+			value:    "2024-01-15 10:30:00-05:00",
+			colType:  types.TIMESTAMP,
+			expected: "2024-01-15T15:30:00Z", // Converted to UTC
 			wantErr:  false,
 		},
 		{
@@ -490,9 +664,13 @@ func TestParseBoolValue(t *testing.T) {
 		{"true", true, false},
 		{"TRUE", true, false},
 		{"True", true, false},
+		{"t", true, false},
+		{"T", true, false},
 		{"false", false, false},
 		{"FALSE", false, false},
 		{"False", false, false},
+		{"f", false, false},
+		{"F", false, false},
 		{"yes", true, false},
 		{"YES", true, false},
 		{"no", false, false},
@@ -501,6 +679,7 @@ func TestParseBoolValue(t *testing.T) {
 		{"Y", true, false},
 		{"n", false, false},
 		{"N", false, false},
+		// 1/0 are still parsed (for explicit schemas) but not auto-detected
 		{"1", true, false},
 		{"0", false, false},
 		{"maybe", false, true},
@@ -534,12 +713,13 @@ func TestParseAndConvertDate(t *testing.T) {
 		wantErr  bool
 	}{
 		{"2024-01-15", "2024-01-15", false},
-		{"15/01/2024", "2024-01-15", false},
-		{"01/15/2024", "2024-01-15", false},
-		{"15-01-2024", "2024-01-15", false},
-		{"01-15-2024", "2024-01-15", false},
+		// UK/US formats not supported
+		{"15/01/2024", "", true},
+		{"01/15/2024", "", true},
+		{"15-01-2024", "", true},
+		{"01-15-2024", "", true},
 		{"invalid", "", true},
-		{"2024/01/15", "", true}, // Not a supported format
+		{"2024/01/15", "", true}, // Slashes are not supported
 	}
 
 	for _, tc := range testCases {
@@ -557,6 +737,111 @@ func TestParseAndConvertDate(t *testing.T) {
 			}
 			if result != tc.expected {
 				t.Errorf("parseAndConvertDate(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseTimeValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"10:30:00", "10:30:00.000000", false},
+		{"10:30:00.123456", "10:30:00.123456", false},
+		{"10:30:00.123", "10:30:00.123000", false},
+		{"23:59:59", "23:59:59.000000", false},
+		{"00:00:00", "00:00:00.000000", false},
+		{"invalid", "", true},
+		{"10:30", "", true}, // Missing seconds
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := parseTimeValue(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseTimeValue(%q) expected error but got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseTimeValue(%q) unexpected error: %v", tc.input, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("parseTimeValue(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseDatetimeValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"2024-01-15 10:30:00", "2024-01-15 10:30:00.000000", false},
+		{"2024-01-15 10:30:00.123456", "2024-01-15 10:30:00.123456", false},
+		{"2024-01-15T10:30:00", "2024-01-15 10:30:00.000000", false},
+		{"2024-01-15T10:30:00.123456", "2024-01-15 10:30:00.123456", false},
+		{"invalid", "", true},
+		{"2024-01-15", "", true}, // No time
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := parseDatetimeValue(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseDatetimeValue(%q) expected error but got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseDatetimeValue(%q) unexpected error: %v", tc.input, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("parseDatetimeValue(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseTimestampValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"2024-01-15T10:30:00Z", "2024-01-15T10:30:00Z", false},
+		{"2024-01-15 10:30:00Z", "2024-01-15T10:30:00Z", false},
+		{"2024-01-15T10:30:00-05:00", "2024-01-15T15:30:00Z", false}, // Converted to UTC
+		{"2024-01-15 10:30:00 UTC", "2024-01-15T10:30:00Z", false},
+		{"2018/08/19 12:11:35", "2018-08-19T12:11:35Z", false}, // Slash date
+		// Unix timestamps CAN be parsed (for explicit schema) even though not auto-detected
+		{"1534680695", "2018-08-19T12:11:35Z", false},
+		{"invalid", "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := parseTimestampValue(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseTimestampValue(%q) expected error but got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseTimestampValue(%q) unexpected error: %v", tc.input, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("parseTimestampValue(%q) = %q, want %q", tc.input, result, tc.expected)
 			}
 		})
 	}

--- a/server/csv_autodetect_test.go
+++ b/server/csv_autodetect_test.go
@@ -651,6 +651,57 @@ func TestDetectSchema(t *testing.T) {
 			expectedFields:  nil,
 			wantErr:         true,
 		},
+		{
+			// skipLeadingRows=1 means only skip the header row, which is already
+			// extracted, so all data rows should be used for type inference
+			name: "skip_leading_rows_1",
+			records: [][]string{
+				{"name", "value"},
+				{"Alice", "100"},
+				{"Bob", "200"},
+				{"Charlie", "300"},
+			},
+			skipLeadingRows: 1,
+			expectedFields: map[string]string{
+				"name":  "STRING",
+				"value": "INTEGER",
+			},
+			wantErr: false,
+		},
+		{
+			// skipLeadingRows=2 means skip header + 1 data row, so type inference
+			// should only see rows after the first data row
+			name: "skip_leading_rows_2",
+			records: [][]string{
+				{"name", "value"},
+				{"SKIP_ME", "not_a_number"}, // This row should be skipped
+				{"Bob", "200"},
+				{"Charlie", "300"},
+			},
+			skipLeadingRows: 2,
+			expectedFields: map[string]string{
+				"name":  "STRING",
+				"value": "INTEGER", // Would be STRING if first data row wasn't skipped
+			},
+			wantErr: false,
+		},
+		{
+			// skipLeadingRows=3 means skip header + 2 data rows
+			name: "skip_leading_rows_3",
+			records: [][]string{
+				{"id", "score"},
+				{"skip1", "not_number"},
+				{"skip2", "also_not_number"},
+				{"1", "95.5"},
+				{"2", "88.0"},
+			},
+			skipLeadingRows: 3,
+			expectedFields: map[string]string{
+				"id":    "INTEGER",
+				"score": "FLOAT",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/server/csv_autodetect_test.go
+++ b/server/csv_autodetect_test.go
@@ -1,0 +1,690 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/goccy/bigquery-emulator/types"
+)
+
+func TestIsNullValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"", true},
+		{"  ", true},
+		{"null", true},
+		{"NULL", true},
+		{"Null", true},
+		{" null ", true},
+		{"0", false},
+		{"false", false},
+		{"none", false},
+		{"hello", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isNullValue(tc.input)
+			if result != tc.expected {
+				t.Errorf("isNullValue(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsBool(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"true", true},
+		{"false", true},
+		{"TRUE", true},
+		{"FALSE", true},
+		{"True", true},
+		{"yes", true},
+		{"no", true},
+		{"YES", true},
+		{"NO", true},
+		{"y", true},
+		{"n", true},
+		{"Y", true},
+		{"N", true},
+		{"1", true},
+		{"0", true},
+		{"", false},
+		{"maybe", false},
+		{"2", false},
+		{"truee", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isBool(tc.input)
+			if result != tc.expected {
+				t.Errorf("isBool(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsInteger(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"0", true},
+		{"1", true},
+		{"-1", true},
+		{"123456789", true},
+		{"-123456789", true},
+		{"  42  ", true},
+		{"1.5", false},
+		{"1e5", false},
+		{"abc", false},
+		{"", false},
+		{"12.0", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isInteger(tc.input)
+			if result != tc.expected {
+				t.Errorf("isInteger(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsFloat(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"0", true},
+		{"1", true},
+		{"1.5", true},
+		{"-1.5", true},
+		{"3.14159", true},
+		{"1e5", true},
+		{"1.5e-10", true},
+		{"  3.14  ", true},
+		{"abc", false},
+		{"", false},
+		{"1.2.3", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := isFloat(tc.input)
+			if result != tc.expected {
+				t.Errorf("isFloat(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectDateFormat(t *testing.T) {
+	testCases := []struct {
+		name           string
+		values         []string
+		expectedLayout string
+	}{
+		{
+			name:           "iso_format",
+			values:         []string{"2024-01-15", "2024-12-31"},
+			expectedLayout: "2006-01-02",
+		},
+		{
+			name:           "uk_format_unambiguous",
+			values:         []string{"15/01/2024", "25/12/2024"},
+			expectedLayout: "02/01/2006",
+		},
+		{
+			name:           "us_format_unambiguous",
+			values:         []string{"01/15/2024", "12/25/2024"},
+			expectedLayout: "01/02/2006",
+		},
+		{
+			name:           "uk_dash_format",
+			values:         []string{"15-01-2024", "25-12-2024"},
+			expectedLayout: "02-01-2006",
+		},
+		{
+			name:           "ambiguous_defaults_to_iso",
+			values:         []string{"2024-01-05"},
+			expectedLayout: "2006-01-02",
+		},
+		{
+			name:           "ambiguous_slash_defaults_to_uk",
+			values:         []string{"01/02/2024"},
+			expectedLayout: "02/01/2006", // UK is preferred over US when ambiguous
+		},
+		{
+			name:           "not_a_date",
+			values:         []string{"hello", "world"},
+			expectedLayout: "",
+		},
+		{
+			name:           "empty_values",
+			values:         []string{},
+			expectedLayout: "",
+		},
+		{
+			name:           "mixed_valid_invalid",
+			values:         []string{"2024-01-15", "not-a-date"},
+			expectedLayout: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := detectDateFormat(tc.values)
+			if result != tc.expectedLayout {
+				t.Errorf("detectDateFormat(%v) = %q, want %q", tc.values, result, tc.expectedLayout)
+			}
+		})
+	}
+}
+
+func TestInferFieldType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		rows         [][]string
+		colIndex     int
+		expectedType string
+	}{
+		{
+			name:         "bool_true_false",
+			rows:         [][]string{{"true"}, {"false"}, {"true"}},
+			colIndex:     0,
+			expectedType: "BOOL",
+		},
+		{
+			name:         "bool_yes_no",
+			rows:         [][]string{{"yes"}, {"no"}, {"YES"}},
+			colIndex:     0,
+			expectedType: "BOOL",
+		},
+		{
+			name:         "integer",
+			rows:         [][]string{{"1"}, {"42"}, {"-100"}},
+			colIndex:     0,
+			expectedType: "INTEGER",
+		},
+		{
+			name:         "float",
+			rows:         [][]string{{"1.5"}, {"3.14"}, {"-0.5"}},
+			colIndex:     0,
+			expectedType: "FLOAT",
+		},
+		{
+			name:         "date_iso",
+			rows:         [][]string{{"2024-01-15"}, {"2024-12-31"}},
+			colIndex:     0,
+			expectedType: "DATE",
+		},
+		{
+			name:         "date_uk",
+			rows:         [][]string{{"15/01/2024"}, {"31/12/2024"}},
+			colIndex:     0,
+			expectedType: "DATE",
+		},
+		{
+			name:         "string",
+			rows:         [][]string{{"hello"}, {"world"}},
+			colIndex:     0,
+			expectedType: "STRING",
+		},
+		{
+			name:         "mixed_to_string",
+			rows:         [][]string{{"1"}, {"hello"}},
+			colIndex:     0,
+			expectedType: "STRING",
+		},
+		{
+			name:         "all_null",
+			rows:         [][]string{{""}, {"null"}, {"NULL"}},
+			colIndex:     0,
+			expectedType: "STRING",
+		},
+		{
+			name:         "integer_with_nulls",
+			rows:         [][]string{{"1"}, {""}, {"3"}},
+			colIndex:     0,
+			expectedType: "INTEGER",
+		},
+		{
+			name:         "second_column",
+			rows:         [][]string{{"a", "1"}, {"b", "2"}, {"c", "3"}},
+			colIndex:     1,
+			expectedType: "INTEGER",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := inferFieldType(tc.rows, tc.colIndex)
+			if result != tc.expectedType {
+				t.Errorf("inferFieldType(%v, %d) = %q, want %q", tc.rows, tc.colIndex, result, tc.expectedType)
+			}
+		})
+	}
+}
+
+func TestSelectSampleRows(t *testing.T) {
+	testCases := []struct {
+		name        string
+		rows        [][]string
+		maxSamples  int
+		expectedLen int
+	}{
+		{
+			name:        "fewer_than_max",
+			rows:        [][]string{{"a"}, {"b"}, {"c"}},
+			maxSamples:  10,
+			expectedLen: 3,
+		},
+		{
+			name:        "exactly_max",
+			rows:        [][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}},
+			maxSamples:  5,
+			expectedLen: 5,
+		},
+		{
+			name:        "more_than_max",
+			rows:        [][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}, {"j"}, {"k"}, {"l"}},
+			maxSamples:  5,
+			expectedLen: 5,
+		},
+		{
+			name:        "empty",
+			rows:        [][]string{},
+			maxSamples:  10,
+			expectedLen: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := selectSampleRows(tc.rows, tc.maxSamples)
+			if len(result) != tc.expectedLen {
+				t.Errorf("selectSampleRows() returned %d rows, want %d", len(result), tc.expectedLen)
+			}
+			// Verify first and last rows are included if we have more than maxSamples
+			if len(tc.rows) > tc.maxSamples && len(result) > 0 {
+				if result[0][0] != tc.rows[0][0] {
+					t.Errorf("first row not included in sample")
+				}
+				if result[len(result)-1][0] != tc.rows[len(tc.rows)-1][0] {
+					t.Errorf("last row not included in sample")
+				}
+			}
+		})
+	}
+}
+
+func TestConvertCSVValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		colType  types.Type
+		expected interface{}
+		wantErr  bool
+	}{
+		{
+			name:     "integer",
+			value:    "42",
+			colType:  types.INT64,
+			expected: int64(42),
+			wantErr:  false,
+		},
+		{
+			name:     "negative_integer",
+			value:    "-123",
+			colType:  types.INT64,
+			expected: int64(-123),
+			wantErr:  false,
+		},
+		{
+			name:     "float",
+			value:    "3.14",
+			colType:  types.FLOAT64,
+			expected: 3.14,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_true",
+			value:    "true",
+			colType:  types.BOOL,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_false",
+			value:    "false",
+			colType:  types.BOOL,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_yes",
+			value:    "yes",
+			colType:  types.BOOL,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_no",
+			value:    "no",
+			colType:  types.BOOL,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_y",
+			value:    "Y",
+			colType:  types.BOOL,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "bool_n",
+			value:    "N",
+			colType:  types.BOOL,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "date_iso",
+			value:    "2024-01-15",
+			colType:  types.DATE,
+			expected: "2024-01-15",
+			wantErr:  false,
+		},
+		{
+			name:     "date_uk_to_iso",
+			value:    "15/01/2024",
+			colType:  types.DATE,
+			expected: "2024-01-15",
+			wantErr:  false,
+		},
+		{
+			name:     "date_us_to_iso",
+			value:    "01/15/2024",
+			colType:  types.DATE,
+			expected: "2024-01-15",
+			wantErr:  false,
+		},
+		{
+			name:     "string",
+			value:    "hello world",
+			colType:  types.STRING,
+			expected: "hello world",
+			wantErr:  false,
+		},
+		{
+			name:     "null_empty",
+			value:    "",
+			colType:  types.INT64,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "null_literal",
+			value:    "null",
+			colType:  types.STRING,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "null_literal_uppercase",
+			value:    "NULL",
+			colType:  types.INT64,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid_integer",
+			value:    "not_a_number",
+			colType:  types.INT64,
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid_bool",
+			value:    "maybe",
+			colType:  types.BOOL,
+			expected: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := convertCSVValue(tc.value, tc.colType)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("convertCSVValue(%q, %v) expected error but got none", tc.value, tc.colType)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("convertCSVValue(%q, %v) unexpected error: %v", tc.value, tc.colType, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("convertCSVValue(%q, %v) = %v (%T), want %v (%T)", tc.value, tc.colType, result, result, tc.expected, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseBoolValue(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+		wantErr  bool
+	}{
+		{"true", true, false},
+		{"TRUE", true, false},
+		{"True", true, false},
+		{"false", false, false},
+		{"FALSE", false, false},
+		{"False", false, false},
+		{"yes", true, false},
+		{"YES", true, false},
+		{"no", false, false},
+		{"NO", false, false},
+		{"y", true, false},
+		{"Y", true, false},
+		{"n", false, false},
+		{"N", false, false},
+		{"1", true, false},
+		{"0", false, false},
+		{"maybe", false, true},
+		{"", false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := parseBoolValue(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseBoolValue(%q) expected error but got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseBoolValue(%q) unexpected error: %v", tc.input, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("parseBoolValue(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseAndConvertDate(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"2024-01-15", "2024-01-15", false},
+		{"15/01/2024", "2024-01-15", false},
+		{"01/15/2024", "2024-01-15", false},
+		{"15-01-2024", "2024-01-15", false},
+		{"01-15-2024", "2024-01-15", false},
+		{"invalid", "", true},
+		{"2024/01/15", "", true}, // Not a supported format
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result, err := parseAndConvertDate(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("parseAndConvertDate(%q) expected error but got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseAndConvertDate(%q) unexpected error: %v", tc.input, err)
+				return
+			}
+			if result != tc.expected {
+				t.Errorf("parseAndConvertDate(%q) = %q, want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectSchema(t *testing.T) {
+	h := &uploadContentHandler{}
+
+	testCases := []struct {
+		name            string
+		records         [][]string
+		skipLeadingRows int64
+		expectedFields  map[string]string // column name -> type
+		wantErr         bool
+	}{
+		{
+			name: "basic_types",
+			records: [][]string{
+				{"name", "age", "score", "active"},
+				{"Alice", "30", "95.5", "true"},
+				{"Bob", "25", "88.0", "false"},
+			},
+			skipLeadingRows: 0,
+			expectedFields: map[string]string{
+				"name":   "STRING",
+				"age":    "INTEGER",
+				"score":  "FLOAT",
+				"active": "BOOL",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with_dates",
+			records: [][]string{
+				{"event", "date"},
+				{"Birthday", "2024-01-15"},
+				{"Anniversary", "2024-12-31"},
+			},
+			skipLeadingRows: 0,
+			expectedFields: map[string]string{
+				"event": "STRING",
+				"date":  "DATE",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with_nulls",
+			records: [][]string{
+				{"id", "value"},
+				{"1", "100"},
+				{"2", ""},
+				{"3", "null"},
+				{"4", "200"},
+			},
+			skipLeadingRows: 0,
+			expectedFields: map[string]string{
+				"id":    "INTEGER",
+				"value": "INTEGER",
+			},
+			wantErr: false,
+		},
+		{
+			name: "all_null_column",
+			records: [][]string{
+				{"id", "empty"},
+				{"1", ""},
+				{"2", "null"},
+			},
+			skipLeadingRows: 0,
+			expectedFields: map[string]string{
+				"id":    "INTEGER",
+				"empty": "STRING",
+			},
+			wantErr: false,
+		},
+		{
+			name: "header_only",
+			records: [][]string{
+				{"col1", "col2"},
+			},
+			skipLeadingRows: 0,
+			expectedFields: map[string]string{
+				"col1": "STRING",
+				"col2": "STRING",
+			},
+			wantErr: false,
+		},
+		{
+			name:            "empty_csv",
+			records:         [][]string{},
+			skipLeadingRows: 0,
+			expectedFields:  nil,
+			wantErr:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := h.detectSchema(tc.records, tc.skipLeadingRows)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("detectSchema() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("detectSchema() unexpected error: %v", err)
+				return
+			}
+
+			if len(schema.Fields) != len(tc.expectedFields) {
+				t.Errorf("detectSchema() returned %d fields, want %d", len(schema.Fields), len(tc.expectedFields))
+				return
+			}
+
+			for _, field := range schema.Fields {
+				expectedType, ok := tc.expectedFields[field.Name]
+				if !ok {
+					t.Errorf("unexpected field %q in schema", field.Name)
+					continue
+				}
+				if field.Type != expectedType {
+					t.Errorf("field %q has type %q, want %q", field.Name, field.Type, expectedType)
+				}
+				if field.Mode != "NULLABLE" {
+					t.Errorf("field %q has mode %q, want NULLABLE", field.Name, field.Mode)
+				}
+			}
+		})
+	}
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -408,6 +408,277 @@ func (h *uploadContentHandler) normalizeColumnNameForJSONData(columnMap map[stri
 	}
 }
 
+// CSV Schema Detection and Type Inference
+
+// dateFormat represents a date format pattern with its Go layout
+type dateFormat struct {
+	pattern string
+	layout  string
+}
+
+var dateFormats = []dateFormat{
+	{"ISO", "2006-01-02"},     // YYYY-MM-DD
+	{"UK", "02/01/2006"},      // DD/MM/YYYY
+	{"US", "01/02/2006"},      // MM/DD/YYYY
+	{"UK_DASH", "02-01-2006"}, // DD-MM-YYYY
+	{"US_DASH", "01-02-2006"}, // MM-DD-YYYY
+}
+
+// isNullValue returns true if the value represents NULL
+func isNullValue(v string) bool {
+	lower := strings.ToLower(strings.TrimSpace(v))
+	return lower == "" || lower == "null"
+}
+
+// isBool returns true if the value can be parsed as a boolean
+func isBool(v string) bool {
+	lower := strings.ToLower(strings.TrimSpace(v))
+	switch lower {
+	case "true", "false", "yes", "no", "y", "n", "1", "0":
+		return true
+	}
+	return false
+}
+
+// isInteger returns true if the value can be parsed as an integer
+func isInteger(v string) bool {
+	_, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	return err == nil
+}
+
+// isFloat returns true if the value can be parsed as a float
+func isFloat(v string) bool {
+	_, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+	return err == nil
+}
+
+// allMatch returns true if all values satisfy the predicate
+func allMatch(values []string, predicate func(string) bool) bool {
+	for _, v := range values {
+		if !predicate(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// splitDateParts splits a date string by common separators
+func splitDateParts(v string) []string {
+	for _, sep := range []string{"-", "/", "."} {
+		if parts := strings.Split(v, sep); len(parts) >= 2 {
+			return parts
+		}
+	}
+	return nil
+}
+
+// detectDateFormat examines all values to determine the most likely date format
+// Returns the Go layout string, or empty string if not a date column
+func detectDateFormat(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	// Track which formats are still valid
+	validFormats := make(map[string]bool)
+	for _, df := range dateFormats {
+		validFormats[df.pattern] = true
+	}
+
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+
+		// Eliminate formats that can't parse this value
+		for _, df := range dateFormats {
+			if validFormats[df.pattern] {
+				if _, err := time.Parse(df.layout, v); err != nil {
+					validFormats[df.pattern] = false
+				}
+			}
+		}
+
+		// Use day > 12 to disambiguate UK vs US format
+		parts := splitDateParts(v)
+		if len(parts) >= 2 {
+			first, _ := strconv.Atoi(parts[0])
+			second, _ := strconv.Atoi(parts[1])
+
+			if first > 12 {
+				// First part > 12, can't be month, so eliminate US format
+				validFormats["US"] = false
+				validFormats["US_DASH"] = false
+			}
+			if second > 12 {
+				// Second part > 12, can't be month, so eliminate UK format
+				validFormats["UK"] = false
+				validFormats["UK_DASH"] = false
+			}
+		}
+	}
+
+	// Return the first still-valid format (preference order: ISO, UK, US)
+	for _, df := range dateFormats {
+		if validFormats[df.pattern] {
+			return df.layout
+		}
+	}
+
+	return ""
+}
+
+// selectSampleRows selects a representative sample of rows for type inference
+func selectSampleRows(rows [][]string, maxSamples int) [][]string {
+	if len(rows) <= maxSamples {
+		return rows
+	}
+
+	samples := make([][]string, 0, maxSamples)
+	samples = append(samples, rows[0]) // First row
+
+	// Evenly space the remaining samples
+	remaining := maxSamples - 2
+	step := float64(len(rows)-2) / float64(remaining+1)
+	for i := 1; i <= remaining; i++ {
+		idx := int(float64(i) * step)
+		if idx > 0 && idx < len(rows)-1 {
+			samples = append(samples, rows[idx])
+		}
+	}
+
+	samples = append(samples, rows[len(rows)-1]) // Last row
+	return samples
+}
+
+// inferFieldType infers the BigQuery field type from sample values
+func inferFieldType(rows [][]string, colIndex int) string {
+	// Collect all non-empty, non-null values
+	values := make([]string, 0)
+	for _, row := range rows {
+		if colIndex < len(row) {
+			val := strings.TrimSpace(row[colIndex])
+			if !isNullValue(val) {
+				values = append(values, val)
+			}
+		}
+	}
+
+	if len(values) == 0 {
+		return "STRING" // Default to STRING for all-null columns
+	}
+
+	// Try each type in order of specificity
+	if allMatch(values, isBool) {
+		return "BOOL"
+	}
+	if allMatch(values, isInteger) {
+		return "INTEGER"
+	}
+	if allMatch(values, isFloat) {
+		return "FLOAT"
+	}
+	if detectDateFormat(values) != "" {
+		return "DATE"
+	}
+
+	return "STRING"
+}
+
+// detectSchema samples rows from a CSV and infers the schema
+func (h *uploadContentHandler) detectSchema(records [][]string, skipLeadingRows int64) (*bigqueryv2.TableSchema, error) {
+	if len(records) == 0 {
+		return nil, fmt.Errorf("empty csv file")
+	}
+
+	header := records[0]
+	dataRows := records[1:]
+
+	// Skip leading rows if configured (after header)
+	if skipLeadingRows > 0 && int64(len(dataRows)) > skipLeadingRows {
+		dataRows = dataRows[skipLeadingRows:]
+	}
+
+	if len(dataRows) == 0 {
+		// Only header, create schema with STRING types
+		fields := make([]*bigqueryv2.TableFieldSchema, len(header))
+		for i, colName := range header {
+			fields[i] = &bigqueryv2.TableFieldSchema{
+				Name: colName,
+				Type: "STRING",
+				Mode: "NULLABLE",
+			}
+		}
+		return &bigqueryv2.TableSchema{Fields: fields}, nil
+	}
+
+	// Sample rows for type inference
+	sampleRows := selectSampleRows(dataRows, 10)
+
+	// Infer type for each column
+	fields := make([]*bigqueryv2.TableFieldSchema, len(header))
+	for i, colName := range header {
+		inferredType := inferFieldType(sampleRows, i)
+		fields[i] = &bigqueryv2.TableFieldSchema{
+			Name: colName,
+			Type: inferredType,
+			Mode: "NULLABLE",
+		}
+	}
+
+	return &bigqueryv2.TableSchema{Fields: fields}, nil
+}
+
+// parseBoolValue parses various boolean representations
+func parseBoolValue(v string) (bool, error) {
+	lower := strings.ToLower(strings.TrimSpace(v))
+	switch lower {
+	case "true", "yes", "y", "1":
+		return true, nil
+	case "false", "no", "n", "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean value: %s", v)
+	}
+}
+
+// parseAndConvertDate tries multiple date formats and returns ISO format
+func parseAndConvertDate(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	for _, df := range dateFormats {
+		if t, err := time.Parse(df.layout, v); err == nil {
+			return t.Format("2006-01-02"), nil // Return ISO format
+		}
+	}
+	return "", fmt.Errorf("could not parse date: %s", v)
+}
+
+// convertCSVValue converts a string value to the appropriate Go type based on the column type
+func convertCSVValue(value string, colType types.Type) (interface{}, error) {
+	value = strings.TrimSpace(value)
+
+	// Handle NULL values
+	if isNullValue(value) {
+		return nil, nil
+	}
+
+	switch colType {
+	case types.INT64:
+		return strconv.ParseInt(value, 10, 64)
+	case types.FLOAT64:
+		return strconv.ParseFloat(value, 64)
+	case types.BOOL:
+		return parseBoolValue(value)
+	case types.DATE:
+		return parseAndConvertDate(value)
+	case types.STRING:
+		return value, nil
+	default:
+		return value, nil
+	}
+}
+
 func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentRequest) error {
 	load := r.job.Content().Configuration.Load
 	tableRef := load.DestinationTable
@@ -419,6 +690,28 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	if err != nil {
 		return err
 	}
+
+	// For CSV with autodetect, we need to read the file first to detect schema
+	var csvRecords [][]string
+	if load.SourceFormat == "CSV" {
+		csvRecords, err = csv.NewReader(r.reader).ReadAll()
+		if err != nil {
+			return fmt.Errorf("failed to read csv: %w", err)
+		}
+		if len(csvRecords) == 0 {
+			return fmt.Errorf("failed to find csv header")
+		}
+
+		// If autodetect is enabled and no schema provided, detect schema from CSV
+		if load.Autodetect && (load.Schema == nil || len(load.Schema.Fields) == 0) {
+			detectedSchema, err := h.detectSchema(csvRecords, load.SkipLeadingRows)
+			if err != nil {
+				return fmt.Errorf("failed to detect schema: %w", err)
+			}
+			load.Schema = detectedSchema
+		}
+	}
+
 	if table == nil {
 		if load.CreateDisposition == "CREATE_NEVER" {
 			return fmt.Errorf("`%s` is not found", tableRef.TableId)
@@ -454,17 +747,11 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	data := types.Data{}
 	switch sourceFormat {
 	case "CSV":
-		records, err := csv.NewReader(r.reader).ReadAll()
-		if err != nil {
-			return fmt.Errorf("failed to read csv: %w", err)
+		// csvRecords already populated above
+		if len(csvRecords) == 1 {
+			return nil // Only header, no data
 		}
-		if len(records) == 0 {
-			return fmt.Errorf("failed to find csv header")
-		}
-		if len(records) == 1 {
-			return nil
-		}
-		header := records[0]
+		header := csvRecords[0]
 		var ignoreHeader bool
 		for _, col := range header {
 			if _, exists := columnToType[col]; !exists {
@@ -485,18 +772,26 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 				})
 			}
 		}
-		for _, record := range records[1:] {
+
+		// Determine data rows, respecting SkipLeadingRows
+		dataRows := csvRecords[1:]
+		if load.SkipLeadingRows > 0 && int64(len(dataRows)) > load.SkipLeadingRows {
+			dataRows = dataRows[load.SkipLeadingRows:]
+		}
+
+		for _, record := range dataRows {
 			rowData := map[string]interface{}{}
 			if len(record) != len(columns) {
 				return fmt.Errorf("invalid column number: found broken row data: %v", record)
 			}
 			for i := 0; i < len(record); i++ {
 				colData := record[i]
-				if colData == "" {
-					rowData[columns[i].Name] = nil
-				} else {
-					rowData[columns[i].Name] = colData
+				// Convert value based on column type
+				converted, err := convertCSVValue(colData, columns[i].Type)
+				if err != nil {
+					return fmt.Errorf("failed to convert value %q for column %s: %w", colData, columns[i].Name, err)
 				}
+				rowData[columns[i].Name] = converted
 			}
 			data = append(data, rowData)
 		}
@@ -1114,9 +1409,11 @@ const (
 func (h *jobsInsertHandler) importFromGCS(ctx context.Context, r *jobsInsertRequest) (*bigqueryv2.Job, error) {
 	var opts []option.ClientOption
 	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
+		// When STORAGE_EMULATOR_HOST is set, the storage client automatically
+		// detects emulator mode. We only need to add JSON reads and disable auth.
+		// Using option.WithEndpoint() can cause double paths with WithJSONReads().
 		opts = append(
 			opts,
-			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
 			storage.WithJSONReads(),
 			option.WithoutAuthentication(),
 		)
@@ -1247,9 +1544,10 @@ func (h *jobsInsertHandler) importFromGCSObject(ctx context.Context, r *jobsInse
 func (h *jobsInsertHandler) exportToGCS(ctx context.Context, r *jobsInsertRequest) (*bigqueryv2.Job, error) {
 	var opts []option.ClientOption
 	if host := os.Getenv(gcsEmulatorHostEnvName); host != "" {
+		// When STORAGE_EMULATOR_HOST is set, the storage client automatically
+		// detects emulator mode. We only need to disable auth.
 		opts = append(
 			opts,
-			option.WithEndpoint(fmt.Sprintf("%s/storage/v1/", host)),
 			option.WithoutAuthentication(),
 		)
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -339,6 +339,10 @@ func (h *uploadContentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		errorResponse(ctx, w, errJobInternalError(err.Error()))
 		return
 	}
+	if job == nil {
+		errorResponse(ctx, w, errJobInternalError(fmt.Sprintf("job %s not found", jobID)))
+		return
+	}
 	if err := h.Handle(ctx, &uploadContentRequest{
 		server:  server,
 		project: project,
@@ -855,7 +859,11 @@ func convertCSVValue(value string, colType types.Type) (interface{}, error) {
 }
 
 func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentRequest) error {
-	load := r.job.Content().Configuration.Load
+	content := r.job.Content()
+	if content == nil || content.Configuration == nil || content.Configuration.Load == nil {
+		return fmt.Errorf("job configuration is incomplete")
+	}
+	load := content.Configuration.Load
 	tableRef := load.DestinationTable
 	dataset, err := r.project.Dataset(ctx, tableRef.DatasetId)
 	if err != nil {

--- a/server/handler.go
+++ b/server/handler.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -410,19 +411,8 @@ func (h *uploadContentHandler) normalizeColumnNameForJSONData(columnMap map[stri
 
 // CSV Schema Detection and Type Inference
 
-// dateFormat represents a date format pattern with its Go layout
-type dateFormat struct {
-	pattern string
-	layout  string
-}
-
-var dateFormats = []dateFormat{
-	{"ISO", "2006-01-02"},     // YYYY-MM-DD
-	{"UK", "02/01/2006"},      // DD/MM/YYYY
-	{"US", "01/02/2006"},      // MM/DD/YYYY
-	{"UK_DASH", "02-01-2006"}, // DD-MM-YYYY
-	{"US_DASH", "01-02-2006"}, // MM-DD-YYYY
-}
+// dateLayout is the only format BigQuery supports for DATE auto-detection (ISO 8601)
+const dateLayout = "2006-01-02" // YYYY-MM-DD
 
 // isNullValue returns true if the value represents NULL
 func isNullValue(v string) bool {
@@ -430,11 +420,12 @@ func isNullValue(v string) bool {
 	return lower == "" || lower == "null"
 }
 
-// isBool returns true if the value can be parsed as a boolean
+// isBool returns true if the value can be auto-detected as a boolean.
+// Note: BigQuery can parse 1/0 as booleans but does not auto-detect them.
 func isBool(v string) bool {
 	lower := strings.ToLower(strings.TrimSpace(v))
 	switch lower {
-	case "true", "false", "yes", "no", "y", "n", "1", "0":
+	case "true", "false", "t", "f", "yes", "no", "y", "n":
 		return true
 	}
 	return false
@@ -452,6 +443,175 @@ func isFloat(v string) bool {
 	return err == nil
 }
 
+// isDate returns true if the value can be parsed as an ISO date (YYYY-MM-DD)
+func isDate(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	_, err := time.Parse(dateLayout, v)
+	return err == nil
+}
+
+// timeLayouts are the formats BigQuery supports for TIME
+var timeLayouts = []string{
+	"15:04:05.000000", // HH:MM:SS.SSSSSS (microseconds)
+	"15:04:05.000",    // HH:MM:SS.SSS (milliseconds)
+	"15:04:05",        // HH:MM:SS
+}
+
+// isTime returns true if the value can be parsed as a TIME (HH:MM:SS[.SSSSSS])
+func isTime(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	for _, layout := range timeLayouts {
+		if _, err := time.Parse(layout, v); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// datetimeLayouts are the formats BigQuery supports for DATETIME
+var datetimeLayouts = []string{
+	"2006-01-02 15:04:05.000000",
+	"2006-01-02 15:04:05.000",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05.000000",
+	"2006-01-02T15:04:05.000",
+	"2006-01-02T15:04:05",
+}
+
+// isDatetime returns true if the value can be parsed as a DATETIME
+// (date + time, no timezone)
+func isDatetime(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	// Reject if it looks like a timestamp (has timezone indicator)
+	if hasTimezoneIndicator(v) {
+		return false
+	}
+	for _, layout := range datetimeLayouts {
+		if _, err := time.Parse(layout, v); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// timestampLayouts for parsing timestamps with timezone
+var timestampLayouts = []string{
+	// With timezone offset (Z)
+	"2006-01-02T15:04:05.000000Z",
+	"2006-01-02T15:04:05.000Z",
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04Z",
+	"2006-01-02 15:04:05.000000Z",
+	"2006-01-02 15:04:05.000Z",
+	"2006-01-02 15:04:05Z",
+	"2006-01-02 15:04Z",
+	// With timezone offset (+/-HH:MM)
+	"2006-01-02T15:04:05.000000-07:00",
+	"2006-01-02T15:04:05.000-07:00",
+	"2006-01-02T15:04:05-07:00",
+	"2006-01-02T15:04-07:00",
+	"2006-01-02 15:04:05.000000-07:00",
+	"2006-01-02 15:04:05.000-07:00",
+	"2006-01-02 15:04:05-07:00",
+	"2006-01-02 15:04-07:00",
+	"2006-01-02 15:04:05.000000 -07:00",
+	"2006-01-02 15:04:05.000 -07:00",
+	"2006-01-02 15:04:05 -07:00",
+	"2006-01-02 15:04 -07:00",
+	// With timezone name (UTC)
+	"2006-01-02 15:04:05.000000 UTC",
+	"2006-01-02 15:04:05.000 UTC",
+	"2006-01-02 15:04:05 UTC",
+	"2006-01-02 15:04 UTC",
+	// Slash separator variants (BigQuery supports YYYY/MM/DD for timestamps)
+	"2006/01/02 15:04:05.000000",
+	"2006/01/02 15:04:05.000",
+	"2006/01/02 15:04:05",
+	"2006/01/02 15:04",
+}
+
+// tzOffsetRegex matches timezone offsets at the end of a string
+var tzOffsetRegex = regexp.MustCompile(`[+-]\d{2}:?\d{0,2}$`)
+
+// hasTimezoneIndicator checks if a string contains timezone information
+func hasTimezoneIndicator(v string) bool {
+	// Check for Z suffix
+	if strings.HasSuffix(v, "Z") {
+		return true
+	}
+	// Check for UTC suffix
+	if strings.HasSuffix(v, " UTC") || strings.HasSuffix(v, "UTC") {
+		return true
+	}
+	// Check for offset pattern like +05:00, -07:00, +0530, -05
+	return tzOffsetRegex.MatchString(v)
+}
+
+// unixTimestampRegex matches Unix epoch timestamps (integer or scientific notation)
+var unixTimestampRegex = regexp.MustCompile(`^-?\d+(\.\d+)?([eE][+-]?\d+)?$`)
+
+// isUnixTimestamp checks if the value looks like a Unix timestamp
+func isUnixTimestamp(v string) bool {
+	v = strings.TrimSpace(v)
+	if !unixTimestampRegex.MatchString(v) {
+		return false
+	}
+	// Parse as float to handle scientific notation
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return false
+	}
+	// Reasonable Unix timestamp range (1970-01-01 to ~2100)
+	// In seconds: 0 to ~4102444800
+	// In milliseconds: 0 to ~4102444800000
+	// Scientific notation like 1.534680695e12 represents milliseconds
+	if f >= 0 && f <= 4102444800 {
+		return true // Looks like seconds
+	}
+	if f >= 1e10 && f <= 4102444800000 {
+		return true // Looks like milliseconds
+	}
+	return false
+}
+
+// isTimestamp returns true if the value can be parsed as a TIMESTAMP
+// (has timezone info or slash-date format)
+// Note: Unix epoch timestamps are NOT auto-detected per BigQuery docs.
+func isTimestamp(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+
+	// Note: Unix epoch timestamps are not auto-detected by BigQuery.
+	// They are treated as numeric types instead.
+
+	// Check if it has timezone indicator or slash-date format
+	hasSlashDate := len(v) >= 10 && v[4] == '/' && v[7] == '/'
+
+	if !hasTimezoneIndicator(v) && !hasSlashDate {
+		return false
+	}
+
+	// Try parsing with known layouts
+	for _, layout := range timestampLayouts {
+		if _, err := time.Parse(layout, v); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // allMatch returns true if all values satisfy the predicate
 func allMatch(values []string, predicate func(string) bool) bool {
 	for _, v := range values {
@@ -460,73 +620,6 @@ func allMatch(values []string, predicate func(string) bool) bool {
 		}
 	}
 	return true
-}
-
-// splitDateParts splits a date string by common separators
-func splitDateParts(v string) []string {
-	for _, sep := range []string{"-", "/", "."} {
-		if parts := strings.Split(v, sep); len(parts) >= 2 {
-			return parts
-		}
-	}
-	return nil
-}
-
-// detectDateFormat examines all values to determine the most likely date format
-// Returns the Go layout string, or empty string if not a date column
-func detectDateFormat(values []string) string {
-	if len(values) == 0 {
-		return ""
-	}
-
-	// Track which formats are still valid
-	validFormats := make(map[string]bool)
-	for _, df := range dateFormats {
-		validFormats[df.pattern] = true
-	}
-
-	for _, v := range values {
-		v = strings.TrimSpace(v)
-		if v == "" {
-			continue
-		}
-
-		// Eliminate formats that can't parse this value
-		for _, df := range dateFormats {
-			if validFormats[df.pattern] {
-				if _, err := time.Parse(df.layout, v); err != nil {
-					validFormats[df.pattern] = false
-				}
-			}
-		}
-
-		// Use day > 12 to disambiguate UK vs US format
-		parts := splitDateParts(v)
-		if len(parts) >= 2 {
-			first, _ := strconv.Atoi(parts[0])
-			second, _ := strconv.Atoi(parts[1])
-
-			if first > 12 {
-				// First part > 12, can't be month, so eliminate US format
-				validFormats["US"] = false
-				validFormats["US_DASH"] = false
-			}
-			if second > 12 {
-				// Second part > 12, can't be month, so eliminate UK format
-				validFormats["UK"] = false
-				validFormats["UK_DASH"] = false
-			}
-		}
-	}
-
-	// Return the first still-valid format (preference order: ISO, UK, US)
-	for _, df := range dateFormats {
-		if validFormats[df.pattern] {
-			return df.layout
-		}
-	}
-
-	return ""
 }
 
 // selectSampleRows selects a representative sample of rows for type inference
@@ -570,17 +663,35 @@ func inferFieldType(rows [][]string, colIndex int) string {
 	}
 
 	// Try each type in order of specificity
+	// Order matters: more restrictive types first
+
+	// 1. BOOL - most restrictive text patterns
 	if allMatch(values, isBool) {
 		return "BOOL"
 	}
+	// 2. INTEGER - pure integers only
 	if allMatch(values, isInteger) {
 		return "INTEGER"
 	}
+	// 3. FLOAT - numeric with decimals
 	if allMatch(values, isFloat) {
 		return "FLOAT"
 	}
-	if detectDateFormat(values) != "" {
+	// 4. TIMESTAMP - has timezone or Unix epoch
+	if allMatch(values, isTimestamp) {
+		return "TIMESTAMP"
+	}
+	// 5. DATETIME - date + time, no timezone
+	if allMatch(values, isDatetime) {
+		return "DATETIME"
+	}
+	// 6. DATE - date only (YYYY-MM-DD)
+	if allMatch(values, isDate) {
 		return "DATE"
+	}
+	// 7. TIME - time only (HH:MM:SS[.SSSSSS])
+	if allMatch(values, isTime) {
+		return "TIME"
 	}
 
 	return "STRING"
@@ -635,28 +746,81 @@ func (h *uploadContentHandler) detectSchema(records [][]string, skipLeadingRows 
 	return &bigqueryv2.TableSchema{Fields: fields}, nil
 }
 
-// parseBoolValue parses various boolean representations
+// parseBoolValue parses various boolean representations.
+// Note: 1/0 are kept for explicit schema parsing even though they're not auto-detected.
 func parseBoolValue(v string) (bool, error) {
 	lower := strings.ToLower(strings.TrimSpace(v))
 	switch lower {
-	case "true", "yes", "y", "1":
+	case "true", "t", "yes", "y", "1":
 		return true, nil
-	case "false", "no", "n", "0":
+	case "false", "f", "no", "n", "0":
 		return false, nil
 	default:
 		return false, fmt.Errorf("invalid boolean value: %s", v)
 	}
 }
 
-// parseAndConvertDate tries multiple date formats and returns ISO format
+// parseAndConvertDate parses an ISO date (YYYY-MM-DD) and returns it
 func parseAndConvertDate(v string) (string, error) {
 	v = strings.TrimSpace(v)
-	for _, df := range dateFormats {
-		if t, err := time.Parse(df.layout, v); err == nil {
-			return t.Format("2006-01-02"), nil // Return ISO format
+	if _, err := time.Parse(dateLayout, v); err != nil {
+		return "", fmt.Errorf("could not parse date: %s", v)
+	}
+	return v, nil // Already in ISO format
+}
+
+// parseTimeValue parses a time string and returns it in canonical format
+func parseTimeValue(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	for _, layout := range timeLayouts {
+		if t, err := time.Parse(layout, v); err == nil {
+			// Return in canonical format HH:MM:SS.SSSSSS
+			return t.Format("15:04:05.000000"), nil
 		}
 	}
-	return "", fmt.Errorf("could not parse date: %s", v)
+	return "", fmt.Errorf("could not parse time: %s", v)
+}
+
+// parseDatetimeValue parses a datetime string and returns it in canonical format
+func parseDatetimeValue(v string) (string, error) {
+	v = strings.TrimSpace(v)
+	for _, layout := range datetimeLayouts {
+		if t, err := time.Parse(layout, v); err == nil {
+			// Return in canonical format YYYY-MM-DD HH:MM:SS.SSSSSS
+			return t.Format("2006-01-02 15:04:05.000000"), nil
+		}
+	}
+	return "", fmt.Errorf("could not parse datetime: %s", v)
+}
+
+// parseTimestampValue parses a timestamp string and returns it in RFC3339 format
+func parseTimestampValue(v string) (string, error) {
+	v = strings.TrimSpace(v)
+
+	// Handle Unix timestamp
+	if isUnixTimestamp(v) {
+		f, _ := strconv.ParseFloat(v, 64)
+		var t time.Time
+		if f >= 1e10 {
+			// Milliseconds - convert to time
+			t = time.UnixMilli(int64(f))
+		} else {
+			// Seconds (may have decimal microseconds)
+			sec := int64(f)
+			nsec := int64((f - float64(sec)) * 1e9)
+			t = time.Unix(sec, nsec)
+		}
+		return t.UTC().Format(time.RFC3339Nano), nil
+	}
+
+	// Try all timestamp layouts
+	for _, layout := range timestampLayouts {
+		if t, err := time.Parse(layout, v); err == nil {
+			return t.UTC().Format(time.RFC3339Nano), nil
+		}
+	}
+
+	return "", fmt.Errorf("could not parse timestamp: %s", v)
 }
 
 // convertCSVValue converts a string value to the appropriate Go type based on the column type
@@ -677,6 +841,12 @@ func convertCSVValue(value string, colType types.Type) (interface{}, error) {
 		return parseBoolValue(value)
 	case types.DATE:
 		return parseAndConvertDate(value)
+	case types.TIME:
+		return parseTimeValue(value)
+	case types.DATETIME:
+		return parseDatetimeValue(value)
+	case types.TIMESTAMP:
+		return parseTimestampValue(value)
 	case types.STRING:
 		return value, nil
 	default:

--- a/server/handler.go
+++ b/server/handler.go
@@ -595,9 +595,14 @@ func (h *uploadContentHandler) detectSchema(records [][]string, skipLeadingRows 
 	header := records[0]
 	dataRows := records[1:]
 
-	// Skip leading rows if configured (after header)
-	if skipLeadingRows > 0 && int64(len(dataRows)) > skipLeadingRows {
-		dataRows = dataRows[skipLeadingRows:]
+	// SkipLeadingRows includes the header row, so when using autodetect
+	// (where row 0 is always the header), we should only skip additional
+	// rows if SkipLeadingRows > 1
+	if skipLeadingRows > 1 {
+		skip := int(skipLeadingRows) - 1 // -1 because header is already handled
+		if skip < len(dataRows) {
+			dataRows = dataRows[skip:]
+		}
 	}
 
 	if len(dataRows) == 0 {
@@ -774,9 +779,14 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 		}
 
 		// Determine data rows, respecting SkipLeadingRows
+		// SkipLeadingRows includes the header row, so we only skip additional
+		// rows if SkipLeadingRows > 1 (header already extracted as row 0)
 		dataRows := csvRecords[1:]
-		if load.SkipLeadingRows > 0 && int64(len(dataRows)) > load.SkipLeadingRows {
-			dataRows = dataRows[load.SkipLeadingRows:]
+		if load.SkipLeadingRows > 1 {
+			skip := int(load.SkipLeadingRows) - 1 // -1 because header is already handled
+			if skip < len(dataRows) {
+				dataRows = dataRows[skip:]
+			}
 		}
 
 		for _, record := range dataRows {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
 	"cloud.google.com/go/storage"
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 	"github.com/goccy/bigquery-emulator/server"
@@ -2112,6 +2113,123 @@ func TestLoadJSON(t *testing.T) {
 		{ID: 2, Name: "Joan"},
 	}, rows); diff != "" {
 		t.Errorf("(-want +got):\n%s", diff)
+	}
+}
+
+func TestCSVAutodetect(t *testing.T) {
+	const (
+		projectName = "test"
+		datasetName = "dataset1"
+		tableName   = "test_table"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create dataset only (no table - it should be created with autodetected schema)
+	project := types.NewProject(projectName, types.NewDataset(datasetName))
+	if err := bqServer.Load(server.StructSource(project)); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Stop(ctx)
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectName,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// CSV with various types
+	csvData := `name,age,score,active,birth_date
+Alice,30,95.5,true,2024-01-15
+Bob,25,88.0,false,2024-06-30
+`
+
+	table := client.Dataset(datasetName).Table(tableName)
+	source := bigquery.NewReaderSource(strings.NewReader(csvData))
+	source.SourceFormat = bigquery.CSV
+	source.AutoDetect = true
+
+	loader := table.LoaderFrom(source)
+	job, err := loader.Run(ctx)
+	if err != nil {
+		t.Fatalf("failed to run load job: %v", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		t.Fatalf("job wait failed: %v", err)
+	}
+	if status.Err() != nil {
+		t.Fatalf("job failed: %v", status.Err())
+	}
+
+	// Verify data was loaded correctly
+	query := client.Query("SELECT name, age, score, active, birth_date FROM " + datasetName + "." + tableName + " ORDER BY name")
+	it, err := query.Read(ctx)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	type csvRow struct {
+		Name      string     `bigquery:"name"`
+		Age       int64      `bigquery:"age"`
+		Score     float64    `bigquery:"score"`
+		Active    bool       `bigquery:"active"`
+		BirthDate civil.Date `bigquery:"birth_date"`
+	}
+
+	var rows []*csvRow
+	for {
+		var r csvRow
+		if err := it.Next(&r); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			t.Fatal(err)
+		}
+		rows = append(rows, &r)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+
+	// Verify first row (Alice)
+	if rows[0].Name != "Alice" {
+		t.Errorf("expected name=Alice, got %s", rows[0].Name)
+	}
+	if rows[0].Age != 30 {
+		t.Errorf("expected age=30, got %d", rows[0].Age)
+	}
+	if rows[0].Score != 95.5 {
+		t.Errorf("expected score=95.5, got %f", rows[0].Score)
+	}
+	if rows[0].Active != true {
+		t.Errorf("expected active=true, got %v", rows[0].Active)
+	}
+
+	// Verify second row (Bob)
+	if rows[1].Name != "Bob" {
+		t.Errorf("expected name=Bob, got %s", rows[1].Name)
+	}
+	if rows[1].Age != 25 {
+		t.Errorf("expected age=25, got %d", rows[1].Age)
+	}
+	if rows[1].Active != false {
+		t.Errorf("expected active=false, got %v", rows[1].Active)
 	}
 }
 

--- a/server/storage_test.go
+++ b/server/storage_test.go
@@ -587,6 +587,10 @@ func TestStorageWrite(t *testing.T) {
 			if err != nil {
 				t.Fatalf("AppendRows first call error: %v", err)
 			}
+			// Wait for result to ensure data is committed before checking row count
+			if _, err := result.GetResult(ctx); err != nil {
+				t.Fatalf("AppendRows first call result error: %v", err)
+			}
 
 			iter := bqClient.Dataset(datasetID).Table(tableID).Read(ctx)
 			resultRowCount := countRows(t, iter)
@@ -603,6 +607,10 @@ func TestStorageWrite(t *testing.T) {
 			result, err = managedStream.AppendRows(ctx, rows, managedwriter.WithOffset(curOffset))
 			if err != nil {
 				t.Fatalf("AppendRows second call error: %v", err)
+			}
+			// Wait for result to ensure data is committed before checking row count
+			if _, err := result.GetResult(ctx); err != nil {
+				t.Fatalf("AppendRows second call result error: %v", err)
 			}
 
 			iter = bqClient.Dataset(datasetID).Table(tableID).Read(ctx)

--- a/test/python/csv_autodetect_test.py
+++ b/test/python/csv_autodetect_test.py
@@ -1,0 +1,304 @@
+"""Tests for CSV schema autodetection."""
+import io
+from datetime import date
+
+from google.cloud import bigquery
+
+from utils.big_query_emulator_container import BQ_EMULATOR_PROJECT_ID
+from utils.big_query_emulator_test_case import (
+    BigQueryAddress,
+    BigQueryEmulatorTestCase,
+)
+
+
+class TestCSVAutodetect(BigQueryEmulatorTestCase):
+    """Tests CSV schema autodetection capabilities."""
+
+    def test_autodetect_basic_types(self) -> None:
+        """Test that basic types are correctly detected from CSV."""
+        csv_data = """name,age,score,active
+Alice,30,95.5,true
+Bob,25,88.0,false
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema was detected
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+
+        self.assertEqual(schema_dict["name"], "STRING")
+        self.assertEqual(schema_dict["age"], "INTEGER")
+        self.assertEqual(schema_dict["score"], "FLOAT")
+        self.assertEqual(schema_dict["active"], "BOOL")
+
+        # Verify data was loaded correctly
+        self.run_query_test(
+            f"SELECT name, age, score, active FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY name",
+            expected_result=[
+                {"name": "Alice", "age": 30, "score": 95.5, "active": True},
+                {"name": "Bob", "age": 25, "score": 88.0, "active": False},
+            ],
+        )
+
+    def test_autodetect_date_iso_format(self) -> None:
+        """Test ISO date format detection (YYYY-MM-DD)."""
+        csv_data = """event,event_date
+Birthday,2024-01-15
+Anniversary,2024-12-31
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["event_date"], "DATE")
+
+        # Verify data
+        self.run_query_test(
+            f"SELECT event, event_date FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY event",
+            expected_result=[
+                {"event": "Anniversary", "event_date": date(2024, 12, 31)},
+                {"event": "Birthday", "event_date": date(2024, 1, 15)},
+            ],
+        )
+
+    def test_autodetect_date_uk_format(self) -> None:
+        """Test UK date format detection (DD/MM/YYYY)."""
+        csv_data = """event,event_date
+Birthday,15/01/2024
+Anniversary,31/12/2024
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["event_date"], "DATE")
+
+        # Verify data - should be converted to ISO format internally
+        self.run_query_test(
+            f"SELECT event, event_date FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY event",
+            expected_result=[
+                {"event": "Anniversary", "event_date": date(2024, 12, 31)},
+                {"event": "Birthday", "event_date": date(2024, 1, 15)},
+            ],
+        )
+
+    def test_autodetect_handles_nulls(self) -> None:
+        """Test that NULL values don't break type detection."""
+        csv_data = """id,value,name
+1,100,Alice
+2,,Bob
+3,null,Charlie
+4,200,
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema - INTEGER type should be detected despite nulls
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["id"], "INTEGER")
+        self.assertEqual(schema_dict["value"], "INTEGER")
+        self.assertEqual(schema_dict["name"], "STRING")
+
+        # Verify data with nulls
+        self.run_query_test(
+            f"SELECT id, value, name FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY id",
+            expected_result=[
+                {"id": 1, "value": 100, "name": "Alice"},
+                {"id": 2, "value": None, "name": "Bob"},
+                {"id": 3, "value": None, "name": "Charlie"},
+                {"id": 4, "value": 200, "name": None},
+            ],
+        )
+
+    def test_autodetect_boolean_variants(self) -> None:
+        """Test various boolean value formats."""
+        csv_data = """id,flag1,flag2,flag3
+1,true,yes,Y
+2,false,no,N
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["flag1"], "BOOL")
+        self.assertEqual(schema_dict["flag2"], "BOOL")
+        self.assertEqual(schema_dict["flag3"], "BOOL")
+
+        # Verify data - all should be converted to true/false
+        self.run_query_test(
+            f"SELECT id, flag1, flag2, flag3 FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY id",
+            expected_result=[
+                {"id": 1, "flag1": True, "flag2": True, "flag3": True},
+                {"id": 2, "flag1": False, "flag2": False, "flag3": False},
+            ],
+        )
+
+    def test_autodetect_mixed_types_fallback_to_string(self) -> None:
+        """Test that mixed types fall back to STRING."""
+        csv_data = """id,mixed_col
+1,100
+2,hello
+3,200
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema - mixed column should be STRING
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["mixed_col"], "STRING")
+
+    def test_autodetect_with_existing_table(self) -> None:
+        """Test that autodetect works with an existing table schema."""
+        # First create the table with explicit schema
+        address = BigQueryAddress(dataset_id="test_dataset", table_id="test_table")
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField("name", "STRING"),
+                bigquery.SchemaField("value", "INTEGER"),
+            ],
+        )
+
+        # Load CSV data - should use existing schema, not autodetect
+        csv_data = """name,value
+Alice,100
+Bob,200
+"""
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,  # Should be ignored since table exists
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify data was loaded
+        self.run_query_test(
+            f"SELECT name, value FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY name",
+            expected_result=[
+                {"name": "Alice", "value": 100},
+                {"name": "Bob", "value": 200},
+            ],
+        )
+
+    def test_autodetect_all_null_column(self) -> None:
+        """Test that columns with all NULL values default to STRING."""
+        csv_data = """id,empty_col
+1,
+2,null
+3,
+"""
+        self.client.create_dataset("test_dataset")
+        table_ref = self.client.dataset("test_dataset").table("test_table")
+
+        job_config = bigquery.LoadJobConfig(
+            source_format=bigquery.SourceFormat.CSV,
+            skip_leading_rows=0,
+            autodetect=True,
+        )
+
+        load_job = self.client.load_table_from_file(
+            io.StringIO(csv_data),
+            table_ref,
+            job_config=job_config,
+        )
+        load_job.result()
+
+        # Verify schema - all-null column should be STRING
+        table = self.client.get_table(table_ref)
+        schema_dict = {f.name: f.field_type for f in table.schema}
+        self.assertEqual(schema_dict["empty_col"], "STRING")

--- a/test/python/csv_autodetect_test.py
+++ b/test/python/csv_autodetect_test.py
@@ -14,6 +14,15 @@ from utils.big_query_emulator_test_case import (
 class TestCSVAutodetect(BigQueryEmulatorTestCase):
     """Tests CSV schema autodetection capabilities."""
 
+    def _get_table_ref(
+        self, dataset_id: str, table_id: str
+    ) -> bigquery.TableReference:
+        """Create a table reference using the non-deprecated API."""
+        return bigquery.TableReference(
+            bigquery.DatasetReference(BQ_EMULATOR_PROJECT_ID, dataset_id),
+            table_id,
+        )
+
     def test_autodetect_basic_types(self) -> None:
         """Test that basic types are correctly detected from CSV."""
         csv_data = """name,age,score,active
@@ -21,7 +30,7 @@ Alice,30,95.5,true
 Bob,25,88.0,false
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -61,7 +70,7 @@ Birthday,2024-01-15
 Anniversary,2024-12-31
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -90,14 +99,18 @@ Anniversary,2024-12-31
             ],
         )
 
-    def test_autodetect_date_uk_format(self) -> None:
-        """Test UK date format detection (DD/MM/YYYY)."""
+    def test_autodetect_date_uk_format_becomes_string(self) -> None:
+        """Test UK date format (DD/MM/YYYY) is not auto-detected as DATE.
+
+        BigQuery only supports ISO 8601 format (YYYY-MM-DD) for DATE auto-detection.
+        UK format dates are treated as STRING.
+        """
         csv_data = """event,event_date
 Birthday,15/01/2024
 Anniversary,31/12/2024
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -112,17 +125,17 @@ Anniversary,31/12/2024
         )
         load_job.result()
 
-        # Verify schema
+        # Verify schema - UK format becomes STRING, not DATE
         table = self.client.get_table(table_ref)
         schema_dict = {f.name: f.field_type for f in table.schema}
-        self.assertEqual(schema_dict["event_date"], "DATE")
+        self.assertEqual(schema_dict["event_date"], "STRING")
 
-        # Verify data - should be converted to ISO format internally
+        # Verify data - kept as string values
         self.run_query_test(
             f"SELECT event, event_date FROM `{BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table` ORDER BY event",
             expected_result=[
-                {"event": "Anniversary", "event_date": date(2024, 12, 31)},
-                {"event": "Birthday", "event_date": date(2024, 1, 15)},
+                {"event": "Anniversary", "event_date": "31/12/2024"},
+                {"event": "Birthday", "event_date": "15/01/2024"},
             ],
         )
 
@@ -135,7 +148,7 @@ Anniversary,31/12/2024
 4,200,
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -175,7 +188,7 @@ Anniversary,31/12/2024
 2,false,no,N
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -214,7 +227,7 @@ Anniversary,31/12/2024
 3,200
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -251,7 +264,7 @@ Anniversary,31/12/2024
 Alice,100
 Bob,200
 """
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,
@@ -283,7 +296,7 @@ Bob,200
 3,
 """
         self.client.create_dataset("test_dataset")
-        table_ref = self.client.dataset("test_dataset").table("test_table")
+        table_ref = self._get_table_ref("test_dataset", "test_table")
 
         job_config = bigquery.LoadJobConfig(
             source_format=bigquery.SourceFormat.CSV,


### PR DESCRIPTION
This PR adds CSV upload support with automatic schema detection to make the emulator work well with the integration tests using the GCS emulator.

It's a reworked version of https://github.com/goccy/bigquery-emulator/pull/387 with tests and removing the GCS URL fix env var workaround.

## Features

Schema Autodetection (load.Autodetect = true):

  - Infers column types from data: BOOL, INTEGER, FLOAT, DATE, STRING
  - Samples up to 10 rows (first, last, and evenly-spaced middle rows) for type inference
  - Handles null values ("", "null", "NULL") correctly during inference
  - Falls back to STRING for all-null columns

Date Format Detection:

  - Supports ISO (2024-01-15), UK (15/01/2024), US (01/15/2024), and dash variants
  - Disambiguates UK vs US format using day values > 12
  - Converts all dates to ISO format on storage

Boolean Parsing:
  - Accepts: true/false, yes/no, y/n, 1/0 (case-insensitive)

`skipLeadingRows` Handling:

  - Correctly interprets BigQuery semantics where `skipLeadingRows` includes the header row
  - `skipLeadingRows=1`: Skip header only (default behaviour with autodetect)
  - `skipLeadingRows=N`: Skip header + (N-1) data rows

  Files Changed

  | File                               | Changes                                                                     |
  |------------------------------------|-----------------------------------------------------------------------------|
  | server/handler.go                  | CSV parsing, type inference, schema detection, value conversion |
  | server/csv_autodetect_test.go      | Unit tests for all type detection/conversion functions          |
  | server/server_test.go              | Integration test TestCSVAutodetect                              |
  | test/python/csv_autodetect_test.py | Python integration tests                                        |
