### PR TITLE
Fix duplicate Base64 Encoding of Binary Table Fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Emulator",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/bigquery-emulator/main.go",
+      "env": {
+        "CGO_ENABLED": "1",
+        "CXX": "clang++"
+      },
+      "dlvFlags": ["--check-go-version=false"],
+      "args": ["--project", "emulator"],
+      "buildFlags": "-ldflags='-X main.version=1 -X main.revision=1 -linkmode external'"
+    }
+  ]
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"strings"
@@ -607,5 +608,24 @@ func normalizeData(v interface{}, field *bigqueryv2.TableFieldSchema) (interface
 		}
 		return fields, nil
 	}
+
+	// Byte values are base64-encoded strings in the BigQuery API.
+	// If we use the value as-is and write it into a byte column,
+	// it will be encoded to base64 again, which is then improperly
+	// decoded when it is sent back to the client.
+	if field.Type == string(FieldBytes) && v != nil {
+		str, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid value type %T for BYTES column", v)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(str)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode base64 bytes: %w", err)
+		}
+
+		return decoded, nil
+	}
+
 	return v, nil
 }


### PR DESCRIPTION
Hi there!

We ran into an odd issue with the emulator when working with binary fields in a table. Fetching the data from that table returned it's binary fields as base64 encoded base64 e.g. the follwing bytes: `[72, 101, 108, 108, 111]` ("Hello") would result in `U0dWc2JHOD0=` rather than `SGVsbG8=` when read. I assume this is because the binary values are already encoded as base64 by the client when they are sent to the emulator and inserting them into a binary field in the actual sqllite table will encode them again.

I am not at all familiar with golang or the code base, but I attempted a small fix that will decode the user input to it's binary form before it is inserted into the database (this fixed the issue for us). Please let me know if you have any suggestions for improvements or know of a more appropriate place for the fix.

> I have also added a launch configuration for vscode with all the necessary flags that I used for local debugging. If you rather not have this in your repository I can remove it.

Thank you for your time! :)