### PR TITLE
fix: reject insertAll requests with unknown fields in row data

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"github.com/goccy/bigquery-emulator/internal/contentdata"
 	"html"
 	"io"
 	"mime"
@@ -20,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/goccy/bigquery-emulator/internal/contentdata"
 
 	"cloud.google.com/go/storage"
 	"github.com/goccy/go-json"
@@ -3045,6 +3046,13 @@ func (h *tabledataInsertAllHandler) Handle(ctx context.Context, r *tabledataInse
 		}
 		data = append(data, rowData)
 	}
+
+	// Validate data against schema before insert
+	validationErrors := types.ValidateDataAgainstSchema(content.Schema, data)
+	if len(validationErrors) > 0 {
+		return buildInsertErrorsResponse(validationErrors, len(data)), nil
+	}
+
 	tableDef, err := types.NewTableWithSchema(content, data)
 	if err != nil {
 		return nil, err
@@ -3062,6 +3070,50 @@ func (h *tabledataInsertAllHandler) Handle(ctx context.Context, r *tabledataInse
 		return nil, err
 	}
 	return &bigqueryv2.TableDataInsertAllResponse{}, nil
+}
+
+// buildInsertErrorsResponse builds a BigQuery-compatible error response for insertAll validation errors.
+// When any row has an unknown field, the entire batch is rejected:
+// - Invalid rows get an "invalid" error with the unknown field name
+// - Valid rows get a "stopped" error (they weren't processed because the batch failed)
+func buildInsertErrorsResponse(errors []types.FieldValidationError, totalRows int) *bigqueryv2.TableDataInsertAllResponse {
+	invalidRows := make(map[int]bool)
+	var insertErrors []*bigqueryv2.TableDataInsertAllResponseInsertErrors
+
+	// Add "invalid" errors for rows with unknown fields
+	for _, e := range errors {
+		invalidRows[e.RowIndex] = true
+		insertErrors = append(insertErrors, &bigqueryv2.TableDataInsertAllResponseInsertErrors{
+			Index: int64(e.RowIndex),
+			Errors: []*bigqueryv2.ErrorProto{{
+				DebugInfo:       "",
+				Reason:          "invalid",
+				Location:        e.FieldName,
+				Message:         fmt.Sprintf("no such field: %s.", e.FieldName),
+				ForceSendFields: []string{"DebugInfo"}, // Ensure DebugInfo is included even when empty
+			}},
+			ForceSendFields: []string{"Index"}, // Ensure Index is included even when 0
+		})
+	}
+
+	// Add "stopped" errors for valid rows (they weren't inserted because batch failed)
+	for i := 0; i < totalRows; i++ {
+		if !invalidRows[i] {
+			insertErrors = append(insertErrors, &bigqueryv2.TableDataInsertAllResponseInsertErrors{
+				Index:           int64(i),
+				ForceSendFields: []string{"Index"}, // Ensure Index is included even when 0
+				Errors: []*bigqueryv2.ErrorProto{{
+					Reason:          "stopped",
+					Location:        "",
+					DebugInfo:       "",
+					Message:         "",
+					ForceSendFields: []string{"Location", "DebugInfo", "Message"}, // Ensure all empty fields are included
+				}},
+			})
+		}
+	}
+
+	return &bigqueryv2.TableDataInsertAllResponse{InsertErrors: insertErrors}
 }
 
 func (h *tabledataListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/test/python/emulator_test.py
+++ b/test/python/emulator_test.py
@@ -1,4 +1,5 @@
 """Tests capabilities of the BigQuery emulator."""
+
 import base64
 import datetime
 from datetime import date
@@ -1254,12 +1255,240 @@ FROM UNNEST([
                 {
                     "id": 2,
                     "binary_data": binary_bytes,
-                    "explicit_base64": binary_base64
+                    "explicit_base64": binary_base64,
+                },
+                {"id": 3, "binary_data": empty_bytes, "explicit_base64": empty_base64},
+            ],
+        )
+
+    def test_insert_unknown_fields_valid_row(self) -> None:
+        """
+        Tests resolution of https://github.com/goccy/bigquery-emulator/issues/421
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "age",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+
+        table = self.client.get_table(self._table_ref_for_address(address))
+        valid_rows = [{"name": "Alice", "age": 30}]
+        errors = self.client.insert_rows_json(table, valid_rows)
+
+        self.assertEqual(errors, [])
+
+    def test_insert_unknown_fields_one_bad_field(self) -> None:
+        """
+        Tests resolution of https://github.com/goccy/bigquery-emulator/issues/421
+        Test that inserting a row with one unknown field returns an error with the field name.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "age",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+
+        table = self.client.get_table(self._table_ref_for_address(address))
+        bad_rows = [{"name": "Bob", "age": 25, "unknown_field": "value"}]
+        errors = self.client.insert_rows_json(table, bad_rows)
+
+        self.assertEqual(
+            errors,
+            [
+                {
+                    "index": 0,
+                    "errors": [
+                        {
+                            "reason": "invalid",
+                            "location": "unknown_field",
+                            "debugInfo": "",
+                            "message": "no such field: unknown_field.",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_insert_unknown_fields_multiple_bad_fields(self) -> None:
+        """
+        Tests resolution of https://github.com/goccy/bigquery-emulator/issues/421
+        Test that inserting a row with multiple unknown fields returns an error with one field.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "age",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+
+        table = self.client.get_table(self._table_ref_for_address(address))
+        bad_rows = [
+            {"name": "Charlie", "unknown1": "a", "unknown2": "b", "unknown3": "c"}
+        ]
+        errors = self.client.insert_rows_json(table, bad_rows)
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["index"], 0)
+        self.assertEqual(len(errors[0]["errors"]), 1)
+        self.assertEqual(errors[0]["errors"][0]["reason"], "invalid")
+        # One of the unknown fields should be reported
+        self.assertIn(
+            errors[0]["errors"][0]["location"], ["unknown1", "unknown2", "unknown3"]
+        )
+        self.assertIn("no such field:", errors[0]["errors"][0]["message"])
+
+    def test_insert_unknown_fields_multiple_bad_rows(self) -> None:
+        """
+        Tests resolution of https://github.com/goccy/bigquery-emulator/issues/421
+        Test that inserting multiple bad rows returns errors for all of them.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "age",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+
+        table = self.client.get_table(self._table_ref_for_address(address))
+        bad_rows = [
+            {"name": "Invalid1", "bad_field1": "x"},
+            {"name": "Invalid2", "bad_field2": "y"},
+        ]
+        errors = self.client.insert_rows_json(table, bad_rows)
+
+        # Both rows should have errors
+        self.assertEqual(len(errors), 2)
+
+        error_indices = {e["index"] for e in errors}
+        self.assertEqual(error_indices, {0, 1})
+
+        for error in errors:
+            self.assertEqual(len(error["errors"]), 1)
+            self.assertEqual(error["errors"][0]["reason"], "invalid")
+            self.assertIn("no such field:", error["errors"][0]["message"])
+
+    def test_insert_unknown_fields_mixed_valid_and_invalid(self) -> None:
+        """
+        Tests resolution of https://github.com/goccy/bigquery-emulator/issues/421
+
+        Test inserting mix of valid and invalid rows.
+        Invalid rows should have 'invalid' errors with field location.
+        Valid rows should have 'stopped' errors when other rows fail.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "age",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+
+        table = self.client.get_table(self._table_ref_for_address(address))
+        mixed_rows = [
+            {"name": "Valid1", "age": 20},  # row 0: valid
+            {"name": "Invalid1", "bad_field": "x"},  # row 1: invalid
+            {"name": "Valid2", "age": 30},  # row 2: valid
+            {"name": "Invalid2", "bad1": "a", "bad2": "b"},  # row 3: invalid
+        ]
+        errors = self.client.insert_rows_json(table, mixed_rows)
+
+        self.assertEqual(
+            errors,
+            [
+                {
+                    "index": 1,
+                    "errors": [
+                        {
+                            "reason": "invalid",
+                            "location": "bad_field",
+                            "debugInfo": "",
+                            "message": "no such field: bad_field.",
+                        }
+                    ],
                 },
                 {
-                    "id": 3,
-                    "binary_data": empty_bytes,
-                    "explicit_base64": empty_base64
+                    "index": 3,
+                    "errors": [
+                        {
+                            "reason": "invalid",
+                            "location": "bad1",
+                            "debugInfo": "",
+                            "message": "no such field: bad1.",
+                        }
+                    ],
+                },
+                {
+                    "index": 0,
+                    "errors": [
+                        {
+                            "reason": "stopped",
+                            "location": "",
+                            "debugInfo": "",
+                            "message": "",
+                        }
+                    ],
+                },
+                {
+                    "index": 2,
+                    "errors": [
+                        {
+                            "reason": "stopped",
+                            "location": "",
+                            "debugInfo": "",
+                            "message": "",
+                        }
+                    ],
                 },
             ],
         )

--- a/types/types.go
+++ b/types/types.go
@@ -486,6 +486,7 @@ func NewTableWithSchema(t *bigqueryv2.Table, data Data) (*Table, error) {
 		for k, v := range row {
 			field, exists := nameToFieldMap[k]
 			if !exists {
+				// Skip unknown fields - validation should be done by the caller
 				continue
 			}
 			v, err := normalizeData(v, field)

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,157 @@
+package types
+
+import (
+	"testing"
+
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
+
+func TestValidateDataAgainstSchema(t *testing.T) {
+	schema := &bigqueryv2.TableSchema{
+		Fields: []*bigqueryv2.TableFieldSchema{
+			{Name: "field1", Type: "STRING"},
+			{Name: "field2", Type: "INTEGER"},
+		},
+	}
+
+	t.Run("all valid fields", func(t *testing.T) {
+		data := Data{
+			{"field1": "value1", "field2": 123},
+			{"field1": "value2", "field2": 456},
+		}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 0 {
+			t.Errorf("expected no errors for valid data, got %d errors", len(errors))
+		}
+	})
+
+	t.Run("unknown field in single row", func(t *testing.T) {
+		data := Data{
+			{"field1": "value1", "unknown_field": "bad"},
+		}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 1 {
+			t.Fatalf("expected 1 error, got %d", len(errors))
+		}
+		if errors[0].RowIndex != 0 {
+			t.Errorf("expected row index 0, got %d", errors[0].RowIndex)
+		}
+		if errors[0].FieldName != "unknown_field" {
+			t.Errorf("expected field name 'unknown_field', got '%s'", errors[0].FieldName)
+		}
+	})
+
+	t.Run("unknown fields in multiple rows", func(t *testing.T) {
+		data := Data{
+			{"field1": "value1", "bad_field1": "error"},
+			{"field1": "value2"},
+			{"field2": 123, "bad_field2": "error"},
+		}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 2 {
+			t.Fatalf("expected 2 errors (rows 0 and 2), got %d", len(errors))
+		}
+
+		// Check that we got errors for the correct rows
+		rowsWithErrors := make(map[int]string)
+		for _, e := range errors {
+			rowsWithErrors[e.RowIndex] = e.FieldName
+		}
+
+		if _, ok := rowsWithErrors[0]; !ok {
+			t.Error("expected error for row 0")
+		}
+		if _, ok := rowsWithErrors[2]; !ok {
+			t.Error("expected error for row 2")
+		}
+		if _, ok := rowsWithErrors[1]; ok {
+			t.Error("did not expect error for row 1 (valid row)")
+		}
+	})
+
+	t.Run("only one error per row", func(t *testing.T) {
+		data := Data{
+			{"field1": "value1", "bad1": "error", "bad2": "error", "bad3": "error"},
+		}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 1 {
+			t.Errorf("expected exactly 1 error (one per row), got %d", len(errors))
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		data := Data{}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 0 {
+			t.Errorf("expected no errors for empty data, got %d", len(errors))
+		}
+	})
+
+	t.Run("empty schema allows nothing", func(t *testing.T) {
+		emptySchema := &bigqueryv2.TableSchema{
+			Fields: []*bigqueryv2.TableFieldSchema{},
+		}
+		data := Data{
+			{"any_field": "value"},
+		}
+
+		errors := ValidateDataAgainstSchema(emptySchema, data)
+		if len(errors) != 1 {
+			t.Errorf("expected 1 error for data with empty schema, got %d", len(errors))
+		}
+	})
+
+	t.Run("partial fields allowed", func(t *testing.T) {
+		data := Data{
+			{"field1": "value1"}, // Only field1, missing field2 - should be valid
+		}
+
+		errors := ValidateDataAgainstSchema(schema, data)
+		if len(errors) != 0 {
+			t.Errorf("expected no errors when providing subset of schema fields, got %d", len(errors))
+		}
+	})
+}
+
+func TestNewTableWithSchema_SkipsUnknownFields(t *testing.T) {
+	tableSchema := &bigqueryv2.Table{
+		TableReference: &bigqueryv2.TableReference{
+			TableId: "test_table",
+		},
+		Schema: &bigqueryv2.TableSchema{
+			Fields: []*bigqueryv2.TableFieldSchema{
+				{Name: "valid_field", Type: "STRING"},
+			},
+		},
+	}
+
+	t.Run("skips unknown fields silently", func(t *testing.T) {
+		data := Data{
+			{"valid_field": "value", "unknown_field": "should_be_skipped"},
+		}
+
+		table, err := NewTableWithSchema(tableSchema, data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(table.Data) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(table.Data))
+		}
+
+		// Check that unknown_field was skipped
+		if _, exists := table.Data[0]["unknown_field"]; exists {
+			t.Error("expected unknown_field to be skipped")
+		}
+
+		// Check that valid_field is present
+		if _, exists := table.Data[0]["valid_field"]; !exists {
+			t.Error("expected valid_field to be present")
+		}
+	})
+}

--- a/types/validation.go
+++ b/types/validation.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/go-playground/validator/v10"
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
 )
 
 func TypeValidation(fl validator.FieldLevel) bool {
@@ -29,4 +30,34 @@ func ModeValidation(fl validator.FieldLevel) bool {
 func RegisterTypeValidation(v *validator.Validate) {
 	v.RegisterValidation("type", TypeValidation)
 	v.RegisterValidation("mode", ModeValidation)
+}
+
+// FieldValidationError represents a validation error for a specific field in a row.
+type FieldValidationError struct {
+	RowIndex  int
+	FieldName string
+}
+
+// ValidateDataAgainstSchema validates that all fields in the data exist in the schema.
+// It returns a list of validation errors, one per row that has an unknown field.
+// Only one unknown field is reported per row (matching BigQuery's behavior).
+func ValidateDataAgainstSchema(schema *bigqueryv2.TableSchema, data Data) []FieldValidationError {
+	schemaFields := make(map[string]bool)
+	for _, f := range schema.Fields {
+		schemaFields[f.Name] = true
+	}
+
+	var errors []FieldValidationError
+	for rowIdx, row := range data {
+		for fieldName := range row {
+			if !schemaFields[fieldName] {
+				errors = append(errors, FieldValidationError{
+					RowIndex:  rowIdx,
+					FieldName: fieldName,
+				})
+				break // Only one error per row (matches BigQuery behavior)
+			}
+		}
+	}
+	return errors
 }


### PR DESCRIPTION
This fixes https://github.com/goccy/bigquery-emulator/issues/421


When inserting rows via the tabledata.insertAll API, the emulator now validates that all fields in the row data exist in the table schema. This matches BigQuery's behavior where unknown fields cause the insert to fail.

Implementation:
- Add ValidateDataAgainstSchema() in types/validation.go
- Call validation before insert in tabledataInsertAllHandler
- Return BigQuery-compatible error responses:
  - Invalid rows get "invalid" error with field name in location
  - Valid rows get "stopped" error (batch failed due to other rows)


cc @ohaibbq 