### PR TITLE
fix: allow null parameter types; loosen `QueryParameterValue` marshalling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.venv/

--- a/go.mod
+++ b/go.mod
@@ -118,4 +118,4 @@ require (
 	modernc.org/sqlite v1.37.0
 )
 
-replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.17
+replace github.com/goccy/go-zetasqlite => github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.19

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.51.0/go.mod h1:SZiPHWGOOk3bl8tkevxkoiwPgsIl6CwrWcbwjfHZpdM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 h1:6/0iUd0xrnX7qt+mLNRwg5c0PGv8wpE8K90ryANQwMI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.17 h1:9Ui62Bg4QGOOQeNhQkgo91N6tFDwGuPbPh7zvPIxke0=
-github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.17/go.mod h1:xtUAGxrJMK0vqv5Yj/AYvrcP3g338Tbh9oTyYk1VML8=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.19 h1://hrbIeXf8WRcM1j8DD5K6uR68zBgQFG9cBuV4juZ2o=
+github.com/Recidiviz/go-zetasqlite v0.18.0-recidiviz.19/go.mod h1:xtUAGxrJMK0vqv5Yj/AYvrcP3g338Tbh9oTyYk1VML8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/arrow-go/v18 v18.4.1 h1:q/jVkBWCJOB9reDgaIZIdruLQUb1kbkvOnOFezVH1C4=

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/goccy/go-zetasqlite"
 	"sync"
+
+	"github.com/goccy/go-zetasqlite"
 )
 
 const (
@@ -107,6 +108,8 @@ func (t *Tx) unregister() {
 	t.finalized = true
 }
 
+func (t *Tx) Conn() *ManagedConnection { return t.conn }
+
 func (t *Tx) RollbackIfNotCommitted() error {
 	defer t.unregister()
 	if t.committed {
@@ -203,6 +206,11 @@ func (c *ManagedConnection) ConfigureScope(projectID, datasetID string) *Managed
 	c.ProjectID = projectID
 	c.DatasetID = datasetID
 	return c
+}
+
+// Raw executes the given function with the underlying ZetaSQLite connection.
+func (c *ManagedConnection) Raw(fn func(interface{}) error) error {
+	return c.zetasqliteConnection.Raw(fn)
 }
 
 func (c *ManagedConnection) Begin(ctx context.Context) (*Tx, error) {

--- a/internal/contentdata/repository.go
+++ b/internal/contentdata/repository.go
@@ -5,12 +5,13 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"reflect"
+	"strings"
+
 	"github.com/goccy/go-json"
 	"github.com/goccy/go-zetasqlite"
 	"go.uber.org/zap"
 	bigqueryv2 "google.golang.org/api/bigquery/v2"
-	"reflect"
-	"strings"
 
 	"github.com/goccy/bigquery-emulator/internal/connection"
 	"github.com/goccy/bigquery-emulator/internal/logger"
@@ -195,6 +196,17 @@ func (r *Repository) Query(ctx context.Context, tx *connection.Tx, projectID, da
 		zap.String("query", query),
 		zap.Any("values", values),
 	)
+	// We must pass the query parameters to zetasqlite so the analyzer uses the proper typings
+	if err := tx.Conn().Raw(func(c interface{}) error {
+		zetasqliteConn, ok := c.(*zetasqlite.ZetaSQLiteConn)
+		if !ok {
+			return fmt.Errorf("failed to get ZetaSQLiteConn from %T", c)
+		}
+		zetasqliteConn.SetQueryParameters(params)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to setup connection: %w", err)
+	}
 	rows, err := tx.Tx().QueryContext(ctx, query, values...)
 	if err != nil {
 		return nil, err
@@ -305,6 +317,16 @@ func (r *Repository) queryParameterValueToGoValue(value *bigqueryv2.QueryParamet
 		}
 		return st, nil
 	}
+
+	// Check if the Value field is marked as null in NullFields
+	// This is how Google's API client indicates a null value even though
+	// Value is typed as string (not *string)
+	for _, field := range value.NullFields {
+		if field == "Value" {
+			return nil, nil
+		}
+	}
+
 	return value.Value, nil
 }
 

--- a/server/flexible_rpc_marshalling.go
+++ b/server/flexible_rpc_marshalling.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"strconv"
+
+	"github.com/goccy/go-json"
+	bigqueryv2 "google.golang.org/api/bigquery/v2"
+)
+
+// flexibleQueryRequest wraps bigqueryv2.QueryRequest to handle flexible unmarshalling
+// of query parameter values. The Node.js BigQuery client sends numeric values as JSON
+// numbers, but the generated QueryParameterValue struct expects all values as strings.
+type flexibleQueryRequest struct {
+	bigqueryv2.QueryRequest
+}
+
+// UnmarshalJSON implements custom unmarshalling that converts numeric parameter values
+// to strings to match the expected QueryParameterValue.Value type.
+func (f *flexibleQueryRequest) UnmarshalJSON(data []byte) error {
+	// First unmarshal into a generic map to inspect the structure
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Process queryParameters if present
+	var nullValuePaths [][]int
+	if params, ok := raw["queryParameters"].([]interface{}); ok {
+		nullValuePaths = processQueryParameters(params)
+	}
+
+	// Marshal the modified structure back to JSON
+	modified, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal into the embedded QueryRequest using a type alias to avoid recursion
+	type queryRequestAlias bigqueryv2.QueryRequest
+	if err := json.Unmarshal(modified, (*queryRequestAlias)(&f.QueryRequest)); err != nil {
+		return err
+	}
+
+	// Apply NullFields to parameter values that had null scalar values
+	for _, path := range nullValuePaths {
+		if len(path) > 0 && path[0] < len(f.QueryRequest.QueryParameters) {
+			applyNullField(f.QueryRequest.QueryParameters[path[0]].ParameterValue, path[1:])
+		}
+	}
+
+	return nil
+}
+
+// flexibleJob wraps bigqueryv2.Job to handle flexible unmarshalling
+// of query parameter values in job configurations.
+type flexibleJob struct {
+	bigqueryv2.Job
+}
+
+// UnmarshalJSON implements custom unmarshalling that converts numeric parameter values
+// to strings to match the expected QueryParameterValue.Value type.
+func (f *flexibleJob) UnmarshalJSON(data []byte) error {
+	// First unmarshal into a generic map to inspect the structure
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Process configuration.query.queryParameters if present
+	var nullValuePaths [][]int
+	if config, ok := raw["configuration"].(map[string]interface{}); ok {
+		if query, ok := config["query"].(map[string]interface{}); ok {
+			if params, ok := query["queryParameters"].([]interface{}); ok {
+				nullValuePaths = processQueryParameters(params)
+			}
+		}
+	}
+
+	// Marshal the modified structure back to JSON
+	modified, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal into the embedded Job using a type alias to avoid recursion
+	type jobAlias bigqueryv2.Job
+	if err := json.Unmarshal(modified, (*jobAlias)(&f.Job)); err != nil {
+		return err
+	}
+
+	// Apply NullFields to parameter values that had null scalar values
+	if f.Job.Configuration != nil && f.Job.Configuration.Query != nil {
+		for _, path := range nullValuePaths {
+			if len(path) > 0 && path[0] < len(f.Job.Configuration.Query.QueryParameters) {
+				applyNullField(f.Job.Configuration.Query.QueryParameters[path[0]].ParameterValue, path[1:])
+			}
+		}
+	}
+
+	return nil
+}
+
+// processQueryParameters handles both null tracking and normalization of query parameters.
+// It processes all parameters in the list, collecting paths to null values and normalizing
+// numeric/boolean values to strings. Returns the paths to parameters with null values.
+func processQueryParameters(params []interface{}) [][]int {
+	var nullValuePaths [][]int
+
+	for i := range params {
+		if paramMap, ok := params[i].(map[string]interface{}); ok {
+			if paramValue, ok := paramMap["parameterValue"].(map[string]interface{}); ok {
+				collectNullPaths(paramValue, []int{i}, &nullValuePaths)
+				normalizeParameterValue(paramValue)
+			}
+		}
+	}
+
+	return nullValuePaths
+}
+
+// collectNullPaths walks through a parameter value structure and records paths
+// to any scalar values that are null. This information is used later to set
+// NullFields on the unmarshaled struct.
+func collectNullPaths(paramValue map[string]interface{}, currentPath []int, nullPaths *[][]int) {
+	// Check if the scalar value field is null
+	if value, ok := paramValue["value"]; ok && value == nil {
+		// Record this path as having a null value
+		pathCopy := make([]int, len(currentPath))
+		copy(pathCopy, currentPath)
+		*nullPaths = append(*nullPaths, pathCopy)
+	}
+
+	// Recursively check array values
+	if arrayValues, ok := paramValue["arrayValues"].([]interface{}); ok {
+		for i, arrVal := range arrayValues {
+			if arrValMap, ok := arrVal.(map[string]interface{}); ok {
+				collectNullPaths(arrValMap, append(currentPath, i), nullPaths)
+			}
+		}
+	}
+
+	// Recursively check struct values (note: struct values are keyed by field name, not index)
+	// For simplicity, we'll handle this separately if needed
+}
+
+// applyNullField sets the NullFields on a QueryParameterValue to indicate
+// that the Value field should be serialized as null.
+func applyNullField(pv *bigqueryv2.QueryParameterValue, path []int) {
+	if pv == nil {
+		return
+	}
+
+	if len(path) == 0 {
+		// We've reached the target - mark Value as null
+		pv.NullFields = append(pv.NullFields, "Value")
+		return
+	}
+
+	// Navigate deeper into the structure
+	nextIndex := path[0]
+	remainingPath := path[1:]
+
+	// Check if we're navigating through array values
+	if nextIndex < len(pv.ArrayValues) {
+		applyNullField(pv.ArrayValues[nextIndex], remainingPath)
+	}
+}
+
+// normalizeParameterValue recursively converts numeric values to strings in parameter values
+func normalizeParameterValue(paramValue map[string]interface{}) {
+	// Handle the scalar value field
+	if value, ok := paramValue["value"]; ok {
+		switch v := value.(type) {
+		case float64:
+			// JSON numbers are unmarshalled as float64
+			// Convert to string, using integer format if it's a whole number
+			if v == float64(int64(v)) {
+				paramValue["value"] = strconv.FormatInt(int64(v), 10)
+			} else {
+				paramValue["value"] = strconv.FormatFloat(v, 'f', -1, 64)
+			}
+		case bool:
+			// Convert booleans to string
+			paramValue["value"] = strconv.FormatBool(v)
+		case string:
+			// Already a string, no conversion needed
+		case nil:
+			// Null value, leave as is
+		}
+	}
+
+	// Handle array values recursively
+	if arrayValues, ok := paramValue["arrayValues"].([]interface{}); ok {
+		for _, arrVal := range arrayValues {
+			if arrValMap, ok := arrVal.(map[string]interface{}); ok {
+				normalizeParameterValue(arrValMap)
+			}
+		}
+	}
+
+	// Handle struct values recursively
+	if structValues, ok := paramValue["structValues"].(map[string]interface{}); ok {
+		for _, structVal := range structValues {
+			if structValMap, ok := structVal.(map[string]interface{}); ok {
+				normalizeParameterValue(structValMap)
+			}
+		}
+	}
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -1543,7 +1543,7 @@ func (h *jobsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	server := serverFromContext(ctx)
 	project := projectFromContext(ctx)
-	var job bigqueryv2.Job
+	var job flexibleJob
 	if err := json.NewDecoder(r.Body).Decode(&job); err != nil {
 		errorResponse(ctx, w, errInvalid(err.Error()))
 		return
@@ -1551,7 +1551,7 @@ func (h *jobsInsertHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	res, err := h.Handle(ctx, &jobsInsertRequest{
 		server:  server,
 		project: project,
-		job:     &job,
+		job:     &job.Job,
 	})
 	if err != nil {
 		errorResponse(ctx, w, errInvalidQuery(err.Error()))
@@ -2397,20 +2397,20 @@ func (h *jobsQueryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	server := serverFromContext(ctx)
 	project := projectFromContext(ctx)
-	var req bigqueryv2.QueryRequest
+	var req flexibleQueryRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		errorResponse(ctx, w, errInvalid(err.Error()))
 		return
 	}
 	useInt64Timestamp := false
-	if options := req.FormatOptions; options != nil {
+	if options := req.QueryRequest.FormatOptions; options != nil {
 		useInt64Timestamp = options.UseInt64Timestamp
 	}
 	useInt64Timestamp = useInt64Timestamp || isFormatOptionsUseInt64Timestamp(r)
 	res, err := h.Handle(ctx, &jobsQueryRequest{
 		server:            server,
 		project:           project,
-		queryRequest:      &req,
+		queryRequest:      &req.QueryRequest,
 		useInt64Timestamp: useInt64Timestamp,
 	})
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2950,6 +2950,600 @@ ORDER BY qty DESC;`)
 	if rowCount != 1 {
 		t.Fatal("failed to get result")
 	}
+
+	query = client.Query("SELECT * FROM `test.test_dataset.test_table` WHERE @parameter IS NULL OR 'target text' = @parameter")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name: "parameter",
+			Value: &bigquery.QueryParameterValue{
+				Type: bigquery.StandardSQLDataType{
+					TypeKind: "STRING",
+				},
+				Value: "test",
+			},
+		},
+	}
+	it, err = query.Read(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if err != iterator.Done {
+				t.Fatal(err)
+			}
+			break
+		}
+		if len(row) != 3 {
+			t.Fatalf("failed to get row: %v", row)
+		}
+	}
+
+	query = client.Query("SELECT * FROM UNNEST(@states)")
+	query.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "states",
+			Value: []string{"WA", "VA", "WV", "WY"},
+		},
+	}
+	it, err = query.Read(ctx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		var row []bigquery.Value
+		if err := it.Next(&row); err != nil {
+			if err != iterator.Done {
+				t.Fatal(err)
+			}
+			break
+		}
+		if len(row) != 1 {
+			t.Fatalf("failed to get row: %v", row)
+		}
+	}
+}
+
+// TestQueryWithNumericParameters tests issue #58: https://github.com/Recidiviz/bigquery-emulator/issues/58
+// Verifies that numeric query parameters (INT64, FLOAT64) work correctly in various SQL contexts,
+// particularly in LIMIT clauses where the Node.js client sends numbers as JSON numbers (not strings).
+func TestQueryWithNumericParameters(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "test_dataset"
+		tableID   = "test_table"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test table with 5 rows of sample data
+	project := types.NewProject(
+		projectID,
+		types.NewDataset(
+			datasetID,
+			types.NewTable(
+				tableID,
+				[]*types.Column{
+					types.NewColumn("id", types.INTEGER),
+					types.NewColumn("name", types.STRING),
+					types.NewColumn("value", types.FLOAT),
+				},
+				types.Data{
+					{"id": 1, "name": "Alice", "value": 10.5},
+					{"id": 2, "name": "Bob", "value": 20.7},
+					{"id": 3, "name": "Charlie", "value": 30.2},
+					{"id": 4, "name": "David", "value": 40.9},
+					{"id": 5, "name": "Eve", "value": 50.1},
+				},
+			),
+		),
+	)
+	if err := bqServer.Load(server.StructSource(project)); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	t.Run("INT64 in LIMIT clause", func(t *testing.T) {
+		// This is the exact scenario from issue #58:
+		// Query with LIMIT using a numeric parameter
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			ORDER BY id ASC
+			LIMIT @limit
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "limit", Value: 2}, // Pass as int, not string
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+		// Verify we got Alice and Bob (id 1 and 2)
+		if rows[0][0].(int64) != 1 || rows[1][0].(int64) != 2 {
+			t.Errorf("unexpected row ids: got %v and %v", rows[0][0], rows[1][0])
+		}
+	})
+
+	t.Run("INT64 in WHERE clause", func(t *testing.T) {
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			WHERE id = @id
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "id", Value: 3}, // Numeric parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(rows))
+		}
+		if rows[0][1].(string) != "Charlie" {
+			t.Errorf("expected Charlie, got %v", rows[0][1])
+		}
+	})
+
+	t.Run("INT64 with comparison operators", func(t *testing.T) {
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			WHERE id >= @minId
+			ORDER BY id ASC
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "minId", Value: 4}, // Numeric parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+		// Should get David and Eve (id 4 and 5)
+		if rows[0][0].(int64) != 4 || rows[1][0].(int64) != 5 {
+			t.Errorf("unexpected row ids: got %v and %v", rows[0][0], rows[1][0])
+		}
+	})
+
+	t.Run("FLOAT64 parameter", func(t *testing.T) {
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			WHERE value > @threshold
+			ORDER BY id ASC
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "threshold", Value: 25.5}, // Float parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(rows))
+		}
+		// Should get Charlie, David, and Eve
+		if rows[0][1].(string) != "Charlie" || rows[1][1].(string) != "David" || rows[2][1].(string) != "Eve" {
+			t.Errorf("unexpected names: got %v, %v, %v", rows[0][1], rows[1][1], rows[2][1])
+		}
+	})
+
+	t.Run("Multiple numeric parameters", func(t *testing.T) {
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			WHERE id >= @minId AND id <= @maxId
+			ORDER BY id ASC
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "minId", Value: 2}, // Numeric parameter
+			{Name: "maxId", Value: 4}, // Numeric parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(rows))
+		}
+		// Should get Bob, Charlie, and David (id 2, 3, 4)
+		if rows[0][0].(int64) != 2 || rows[1][0].(int64) != 3 || rows[2][0].(int64) != 4 {
+			t.Errorf("unexpected row ids: got %v, %v, %v", rows[0][0], rows[1][0], rows[2][0])
+		}
+	})
+
+	t.Run("LIMIT with OFFSET", func(t *testing.T) {
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			ORDER BY id ASC
+			LIMIT @limit OFFSET @offset
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "limit", Value: 2}, // Both as numbers
+			{Name: "offset", Value: 2},
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d", len(rows))
+		}
+		// Should get Charlie and David (skipped Alice and Bob)
+		if rows[0][0].(int64) != 3 || rows[1][0].(int64) != 4 {
+			t.Errorf("unexpected row ids: got %v and %v", rows[0][0], rows[1][0])
+		}
+	})
+
+	t.Run("Zero and negative values", func(t *testing.T) {
+		// Test zero as parameter value
+		query := client.Query(`
+			SELECT * FROM test_dataset.test_table
+			WHERE id > @minId
+			ORDER BY id ASC
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "minId", Value: 0}, // Zero as numeric parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rowCount int
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rowCount++
+		}
+
+		if rowCount != 5 {
+			t.Fatalf("expected 5 rows with id > 0, got %d", rowCount)
+		}
+
+		// Test negative number
+		query2 := client.Query(`SELECT @negativeValue as result`)
+		query2.Parameters = []bigquery.QueryParameter{
+			{Name: "negativeValue", Value: -42},
+		}
+
+		it2, err := query2.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var row []bigquery.Value
+		if err := it2.Next(&row); err != nil {
+			t.Fatalf("iterator.Next failed: %v", err)
+		}
+
+		if row[0].(int64) != -42 {
+			t.Errorf("expected -42, got %v", row[0])
+		}
+	})
+}
+
+// TestQueryWithNullParameters tests issue #312: https://github.com/goccy/bigquery-emulator/issues/312
+// Verifies that null parameters work correctly in IS NULL conditions.
+// The issue reported that null string parameters in WHERE clauses with
+// "IS NULL OR parameter = value" patterns caused type inference errors.
+func TestQueryWithNullParameters(t *testing.T) {
+	const (
+		projectID = "test"
+		datasetID = "test_dataset"
+		tableID   = "test_table"
+	)
+
+	ctx := context.Background()
+
+	bqServer, err := server.New(server.TempStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test table with sample data
+	project := types.NewProject(
+		projectID,
+		types.NewDataset(
+			datasetID,
+			types.NewTable(
+				tableID,
+				[]*types.Column{
+					types.NewColumn("id", types.INTEGER),
+					types.NewColumn("name", types.STRING),
+				},
+				types.Data{
+					{"id": 1, "name": "Alice"},
+					{"id": 2, "name": "Bob"},
+					{"id": 3, "name": "Charlie"},
+				},
+			),
+		),
+	)
+	if err := bqServer.Load(server.StructSource(project)); err != nil {
+		t.Fatal(err)
+	}
+
+	testServer := bqServer.TestServer()
+	defer func() {
+		testServer.Close()
+		bqServer.Close()
+	}()
+
+	client, err := bigquery.NewClient(
+		ctx,
+		projectID,
+		option.WithEndpoint(testServer.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	t.Run("Null string parameter with IS NULL check", func(t *testing.T) {
+		// Test with null parameter - should return all rows
+		query := client.Query(`
+			SELECT id, name
+			FROM test_dataset.test_table
+			WHERE @parameter IS NULL OR name = @parameter
+			ORDER BY id
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "parameter", Value: bigquery.NullString{}}, // Null parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		// Since parameter is null, the IS NULL condition is true,
+		// so all rows should be returned
+		if len(rows) != 3 {
+			t.Fatalf("expected 3 rows, got %d", len(rows))
+		}
+		// Verify we got all three people
+		if rows[0][0].(int64) != 1 || rows[1][0].(int64) != 2 || rows[2][0].(int64) != 3 {
+			t.Errorf("unexpected row ids: got %v, %v, %v", rows[0][0], rows[1][0], rows[2][0])
+		}
+	})
+
+	t.Run("Null parameter with specific value fallback", func(t *testing.T) {
+		// Test with specific value - should filter
+		query := client.Query(`
+			SELECT id, name
+			FROM test_dataset.test_table
+			WHERE @parameter IS NULL OR name = @parameter
+			ORDER BY id
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "parameter", Value: "Alice"}, // Non-null parameter
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rows [][]bigquery.Value
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rows = append(rows, row)
+		}
+
+		// Should only get Alice
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d", len(rows))
+		}
+		if rows[0][1].(string) != "Alice" {
+			t.Errorf("expected Alice, got %v", rows[0][1])
+		}
+	})
+
+	t.Run("Null numeric parameter", func(t *testing.T) {
+		query := client.Query(`
+			SELECT id, name
+			FROM test_dataset.test_table
+			WHERE @numParam IS NULL OR id = @numParam
+			ORDER BY id
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "numParam", Value: bigquery.NullInt64{}},
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rowCount int
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rowCount++
+		}
+
+		// Should return all rows since parameter is null
+		if rowCount != 3 {
+			t.Fatalf("expected 3 rows, got %d", rowCount)
+		}
+	})
+
+	t.Run("Multiple null parameters", func(t *testing.T) {
+		query := client.Query(`
+			SELECT id, name
+			FROM test_dataset.test_table
+			WHERE (@param1 IS NULL OR id = @param1)
+			  AND (@param2 IS NULL OR name = @param2)
+			ORDER BY id
+		`)
+		query.Parameters = []bigquery.QueryParameter{
+			{Name: "param1", Value: bigquery.NullInt64{}},
+			{Name: "param2", Value: bigquery.NullString{}},
+		}
+
+		it, err := query.Read(ctx)
+		if err != nil {
+			t.Fatalf("query.Read failed: %v", err)
+		}
+
+		var rowCount int
+		for {
+			var row []bigquery.Value
+			if err := it.Next(&row); err != nil {
+				if err == iterator.Done {
+					break
+				}
+				t.Fatalf("iterator.Next failed: %v", err)
+			}
+			rowCount++
+		}
+
+		// Both are null, so all rows match
+		if rowCount != 3 {
+			t.Fatalf("expected 3 rows, got %d", rowCount)
+		}
+	})
 }
 
 func TestMultipleProject(t *testing.T) {
@@ -3151,7 +3745,6 @@ func TestInformationSchema(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func TestWriteDisposition(t *testing.T) {

--- a/test/node/src/emptyArrayRepeated.test.ts
+++ b/test/node/src/emptyArrayRepeated.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Test for empty array handling in REPEATED fields.
+ *
+ * This test reproduces the issue described in:
+ * https://github.com/goccy/bigquery-emulator/issues/137
+ *
+ * When inserting an empty array into a REPEATED field and then querying it back,
+ * the Node.js BigQuery client crashes because the emulator returns null instead
+ * of an empty array structure.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import {
+  BigQueryEmulatorContainer,
+  BQ_EMULATOR_PROJECT_ID,
+} from './utils/BigQueryEmulatorContainer.js';
+import {
+  createBigQueryClient,
+  createTestHelper,
+  BigQueryTestHelper,
+} from './utils/testSetup.js';
+import { BigQuery } from '@google-cloud/bigquery';
+
+describe('Empty Array in REPEATED Fields', () => {
+  let emulator: BigQueryEmulatorContainer;
+  let client: BigQuery;
+  let helper: BigQueryTestHelper;
+
+  beforeAll(async () => {
+    emulator = await BigQueryEmulatorContainer.start();
+    client = createBigQueryClient(emulator);
+    helper = createTestHelper(client);
+  });
+
+  afterAll(async () => {
+    await emulator.stop();
+  });
+
+  afterEach(async () => {
+    await helper.deleteAllDatasets();
+  });
+
+  it('should handle empty array in REPEATED STRING field', async () => {
+    // Create table with REPEATED STRING field
+    await helper.createTable(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      {
+        fields: [
+          { name: 'id', type: 'INTEGER', mode: 'REQUIRED' },
+          { name: 'tags', type: 'STRING', mode: 'REPEATED' },
+        ],
+      }
+    );
+
+    // Insert row with empty array
+    await helper.insertRows(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      [{ id: 1, tags: [] }]
+    );
+
+    // Query the data back - this should not crash
+    const query = `SELECT id, tags FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\``;
+    const rows = await helper.query(query);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(1);
+    expect(rows[0].tags).toEqual([]);
+  });
+
+  it('should handle empty array in REPEATED INTEGER field', async () => {
+    await helper.createTable(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      {
+        fields: [
+          { name: 'id', type: 'STRING', mode: 'REQUIRED' },
+          { name: 'values', type: 'INTEGER', mode: 'REPEATED' },
+        ],
+      }
+    );
+
+    await helper.insertRows(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      [{ id: 'test1', values: [] }]
+    );
+
+    const query = `SELECT id, values FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\``;
+    const rows = await helper.query(query);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('test1');
+    expect(rows[0].values).toEqual([]);
+  });
+
+  it('should handle mix of empty and non-empty arrays', async () => {
+    await helper.createTable(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      {
+        fields: [
+          { name: 'id', type: 'INTEGER', mode: 'REQUIRED' },
+          { name: 'items', type: 'STRING', mode: 'REPEATED' },
+        ],
+      }
+    );
+
+    await helper.insertRows(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      [
+        { id: 1, items: [] },
+        { id: 2, items: ['apple', 'banana'] },
+        { id: 3, items: [] },
+        { id: 4, items: ['orange'] },
+      ]
+    );
+
+    const query = `SELECT id, items FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\` ORDER BY id`;
+    const rows = await helper.query(query);
+
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toEqual({ id: 1, items: [] });
+    expect(rows[1]).toEqual({ id: 2, items: ['apple', 'banana'] });
+    expect(rows[2]).toEqual({ id: 3, items: [] });
+    expect(rows[3]).toEqual({ id: 4, items: ['orange'] });
+  });
+
+  it('should handle empty arrays in multiple REPEATED fields', async () => {
+    await helper.createTable(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      {
+        fields: [
+          { name: 'id', type: 'INTEGER', mode: 'REQUIRED' },
+          { name: 'tags', type: 'STRING', mode: 'REPEATED' },
+          { name: 'scores', type: 'FLOAT', mode: 'REPEATED' },
+        ],
+      }
+    );
+
+    await helper.insertRows(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      [{ id: 1, tags: [], scores: [] }]
+    );
+
+    const query = `SELECT id, tags, scores FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\``;
+    const rows = await helper.query(query);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ id: 1, tags: [], scores: [] });
+  });
+
+  it('should handle REPEATED STRUCT with empty array', async () => {
+    await helper.createTable(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      {
+        fields: [
+          { name: 'id', type: 'INTEGER', mode: 'REQUIRED' },
+          {
+            name: 'records',
+            type: 'RECORD',
+            mode: 'REPEATED',
+            fields: [
+              { name: 'name', type: 'STRING', mode: 'NULLABLE' },
+              { name: 'value', type: 'INTEGER', mode: 'NULLABLE' },
+            ],
+          },
+        ],
+      }
+    );
+
+    await helper.insertRows(
+      { datasetId: 'test_dataset', tableId: 'test_table' },
+      [{ id: 1, records: [] }]
+    );
+
+    const query = `SELECT id, records FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\``;
+    const rows = await helper.query(query);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(1);
+    expect(rows[0].records).toEqual([]);
+  });
+});

--- a/test/node/src/parameterizedQueries.test.ts
+++ b/test/node/src/parameterizedQueries.test.ts
@@ -345,4 +345,177 @@ describe('Parameterized Queries (Issue #58)', () => {
       expect(rows[0].result).toBe(9007199254740991);
     });
   });
+
+  describe('Issue #234: UNNEST with Array Parameters', () => {
+    it('should handle UNNEST with ARRAY<STRING> parameter', async () => {
+      // https://github.com/goccy/bigquery-emulator/issues/234
+      // Tests that array parameters work with UNNEST
+      const query = `
+        SELECT *
+        FROM UNNEST(@states) AS state
+        ORDER BY state
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          states: ['WA', 'WI', 'WV', 'WY'],
+        },
+      });
+
+      expect(rows).toHaveLength(4);
+      expect(rows[0].state).toBe('WA');
+      expect(rows[1].state).toBe('WI');
+      expect(rows[2].state).toBe('WV');
+      expect(rows[3].state).toBe('WY');
+    });
+
+    it('should handle UNNEST with ARRAY<INT64> parameter', async () => {
+      const query = `
+        SELECT *
+        FROM UNNEST(@numbers) AS num
+        ORDER BY num
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          numbers: [1, 2, 3, 4, 5],
+        },
+      });
+
+      expect(rows).toHaveLength(5);
+      expect(rows[0].num).toBe(1);
+      expect(rows[4].num).toBe(5);
+    });
+
+    it('should handle UNNEST with array parameter in JOIN', async () => {
+      const query = `
+        SELECT t.id, t.name, state
+        FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\` t
+        CROSS JOIN UNNEST(@stateList) AS state
+        WHERE t.id <= 2
+        ORDER BY t.id, state
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          stateList: ['CA', 'NY'],
+        },
+      });
+
+      expect(rows).toHaveLength(4);
+      expect(rows[0].id).toBe(1);
+      expect(rows[0].state).toBe('CA');
+      expect(rows[1].id).toBe(1);
+      expect(rows[1].state).toBe('NY');
+    });
+  });
+
+  describe('Issue #312: Null Parameter Handling', () => {
+    it('should handle null string parameter with IS NULL check', async () => {
+      // https://github.com/goccy/bigquery-emulator/issues/312
+      // Tests that null parameters work correctly in IS NULL conditions
+      const query = `
+        SELECT id, name
+        FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\`
+        WHERE @parameter IS NULL OR name = @parameter
+        ORDER BY id
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          parameter: null, // Null parameter
+        },
+        types: {
+          parameter: 'STRING', // Must specify type for null values
+        },
+      });
+
+      // Since parameter is null, the IS NULL condition is true,
+      // so all rows should be returned
+      expect(rows).toHaveLength(5);
+      expect(rows[0].id).toBe(1);
+      expect(rows[4].id).toBe(5);
+    });
+
+    it('should handle null parameter with specific value fallback', async () => {
+      const query = `
+        SELECT id, name
+        FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\`
+        WHERE @parameter IS NULL OR name = @parameter
+        ORDER BY id
+      `;
+
+      // First with null - should return all rows
+      const [nullRows] = await client.query({
+        query,
+        params: {
+          parameter: null,
+        },
+        types: {
+          parameter: 'STRING',
+        },
+      });
+      expect(nullRows).toHaveLength(5);
+
+      // Then with specific value - should filter
+      const [filteredRows] = await client.query({
+        query,
+        params: {
+          parameter: 'Alice',
+        },
+      });
+      expect(filteredRows).toHaveLength(1);
+      expect(filteredRows[0].name).toBe('Alice');
+    });
+
+    it('should handle null numeric parameter', async () => {
+      const query = `
+        SELECT id, name
+        FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\`
+        WHERE @numParam IS NULL OR id = @numParam
+        ORDER BY id
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          numParam: null,
+        },
+        types: {
+          numParam: 'INT64',
+        },
+      });
+
+      expect(rows).toHaveLength(5);
+    });
+
+    it('should handle multiple null parameters', async () => {
+      const query = `
+        SELECT id, name
+        FROM \`${BQ_EMULATOR_PROJECT_ID}.test_dataset.test_table\`
+        WHERE (@param1 IS NULL OR id = @param1)
+          AND (@param2 IS NULL OR name = @param2)
+        ORDER BY id
+      `;
+
+      const [rows] = await client.query({
+        query,
+        params: {
+          param1: null,
+          param2: null,
+        },
+        types: {
+          param1: 'INT64',
+          param2: 'STRING',
+        },
+      });
+
+      // Both are null, so all rows match
+      expect(rows).toHaveLength(5);
+    });
+  });
 });

--- a/test/node/src/utils/testSetup.ts
+++ b/test/node/src/utils/testSetup.ts
@@ -114,7 +114,7 @@ export class BigQueryTestHelper {
     const [rows] = await this.client.query({
       query,
       location: 'US',
-    });
+    }, {parseJSON: true});
     return rows as T[];
   }
 
@@ -129,7 +129,7 @@ export class BigQueryTestHelper {
       query,
       params,
       location: 'US',
-    });
+    }, {parseJSON: true});
     return rows as T[];
   }
 

--- a/test/python/emulator_test.py
+++ b/test/python/emulator_test.py
@@ -1492,3 +1492,274 @@ FROM UNNEST([
                 },
             ],
         )
+
+    def test_unnest_with_array_parameter(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/234
+
+        Tests that array parameters work correctly with UNNEST operations.
+        The issue reported that UNNEST with parameterized arrays failed with
+        "Values referenced in UNNEST must be arrays" error.
+        """
+        # Test with ARRAY<STRING>
+        query = """
+        SELECT *
+        FROM UNNEST(@states) AS state
+        ORDER BY state
+        """
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ArrayQueryParameter("states", "STRING", ["WA", "WI", "WV", "WY"])
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"state": "WA"},
+                {"state": "WI"},
+                {"state": "WV"},
+                {"state": "WY"},
+            ],
+            job_config=job_config,
+        )
+
+    def test_unnest_with_int_array_parameter(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/234
+
+        Tests UNNEST with integer array parameters.
+        """
+        query = """
+        SELECT *
+        FROM UNNEST(@numbers) AS num
+        ORDER BY num
+        """
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ArrayQueryParameter("numbers", "INT64", [1, 2, 3, 4, 5])
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"num": 1},
+                {"num": 2},
+                {"num": 3},
+                {"num": 4},
+                {"num": 5},
+            ],
+            job_config=job_config,
+        )
+
+    def test_unnest_array_parameter_with_join(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/234
+
+        Tests UNNEST with array parameters in a JOIN operation.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "id",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+            ],
+        )
+        self.load_rows_into_table(
+            address,
+            data=[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+        )
+
+        query = f"""
+        SELECT t.id, t.name, state
+        FROM `{self.project_id}.{address.dataset_id}.{address.table_id}` t
+        CROSS JOIN UNNEST(@states) AS state
+        ORDER BY t.id, state
+        """
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ArrayQueryParameter("states", "STRING", ["CA", "NY"])
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"id": 1, "name": "Alice", "state": "CA"},
+                {"id": 1, "name": "Alice", "state": "NY"},
+                {"id": 2, "name": "Bob", "state": "CA"},
+                {"id": 2, "name": "Bob", "state": "NY"},
+            ],
+            job_config=job_config,
+        )
+
+    def test_null_parameter_with_is_null_check(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/312
+
+        Tests that null parameters work correctly in IS NULL conditions.
+        The issue reported that null string parameters in WHERE clauses with
+        "IS NULL OR parameter = value" patterns caused type inference errors.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "id",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+            ],
+        )
+        self.load_rows_into_table(
+            address,
+            data=[
+                {"id": 1, "name": "Alice"},
+                {"id": 2, "name": "Bob"},
+                {"id": 3, "name": "Charlie"},
+            ],
+        )
+
+        query = f"""
+        SELECT id, name
+        FROM `{self.project_id}.{address.dataset_id}.{address.table_id}`
+        WHERE @parameter IS NULL OR name = @parameter
+        ORDER BY id
+        """
+
+        # Test with null parameter - should return all rows
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("parameter", "STRING", None)
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"id": 1, "name": "Alice"},
+                {"id": 2, "name": "Bob"},
+                {"id": 3, "name": "Charlie"},
+            ],
+            job_config=job_config,
+        )
+
+    def test_null_parameter_with_specific_value(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/312
+
+        Tests that the same query works with both null and non-null parameter values.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "id",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "name",
+                    field_type=bigquery.enums.SqlTypeNames.STRING.value,
+                    mode="REQUIRED",
+                ),
+            ],
+        )
+        self.load_rows_into_table(
+            address,
+            data=[
+                {"id": 1, "name": "Alice"},
+                {"id": 2, "name": "Bob"},
+                {"id": 3, "name": "Charlie"},
+            ],
+        )
+
+        query = f"""
+        SELECT id, name
+        FROM `{self.project_id}.{address.dataset_id}.{address.table_id}`
+        WHERE @parameter IS NULL OR name = @parameter
+        ORDER BY id
+        """
+
+        # Test with specific value - should filter
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("parameter", "STRING", "Alice")
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"id": 1, "name": "Alice"},
+            ],
+            job_config=job_config,
+        )
+
+    def test_null_numeric_parameter(self) -> None:
+        """Tests resolution of https://github.com/goccy/bigquery-emulator/issues/312
+
+        Tests that null numeric parameters work correctly.
+        """
+        address = BigQueryAddress(dataset_id=_DATASET_1, table_id=_TABLE_1)
+        self.create_mock_table(
+            address,
+            schema=[
+                bigquery.SchemaField(
+                    "id",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="REQUIRED",
+                ),
+                bigquery.SchemaField(
+                    "value",
+                    field_type=bigquery.enums.SqlTypeNames.INTEGER.value,
+                    mode="NULLABLE",
+                ),
+            ],
+        )
+        self.load_rows_into_table(
+            address,
+            data=[
+                {"id": 1, "value": 10},
+                {"id": 2, "value": 20},
+                {"id": 3, "value": 30},
+            ],
+        )
+
+        query = f"""
+        SELECT id, value
+        FROM `{self.project_id}.{address.dataset_id}.{address.table_id}`
+        WHERE @numParam IS NULL OR value = @numParam
+        ORDER BY id
+        """
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter("numParam", "INT64", None)
+            ]
+        )
+
+        self.run_query_test(
+            query,
+            expected_result=[
+                {"id": 1, "value": 10},
+                {"id": 2, "value": 20},
+                {"id": 3, "value": 30},
+            ],
+            job_config=job_config,
+        )

--- a/test/python/utils/big_query_emulator_test_case.py
+++ b/test/python/utils/big_query_emulator_test_case.py
@@ -212,8 +212,9 @@ class BigQueryEmulatorTestCase(unittest.TestCase):
             query_str: str,
             expected_result: Iterable[Dict[str, Any]],
             enforce_order: bool = True,
+            **kwargs
     ) -> None:
-        query_job = self.client.query(query=query_str)
+        query_job = self.client.query(query=query_str, **kwargs)
         contents = list({key: row.get(key) for key in row.keys()} for row in query_job.result())
         if enforce_order:
             self.assertEqual(expected_result, contents)


### PR DESCRIPTION
We need to depend on the published generated protos for the BigQuery API. These protos type `QueryParameterValue.Value` as a string which is not compatible with how the Python/Node clients send the parameters. This implements custom marshalling to handle cases of null, boolean, and numeric values.

closes #58
closes goccy/bigquery-emulator#312
closes goccy/bigquery-emulator#234
closes goccy/bigquery-emulator#137