### PR TITLE
Pin all GitHub Actions to SHA refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,11 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: cache for linux
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: runner.os == 'Linux'
         with:
           path: |
@@ -42,7 +42,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{matrix.asset_name}}-
       - name: cache for macOS
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         if: runner.os == 'macOS'
         with:
           path: |
@@ -51,13 +51,13 @@ jobs:
           key: ${{ runner.os }}-go-${{matrix.asset_name}}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{matrix.asset_name}}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         name: Build and push by digest
         id: build
         with:
@@ -75,7 +75,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.asset_name }}
           path: ${{ runner.temp }}/digests/*
@@ -93,16 +93,16 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
@@ -31,9 +31,9 @@ jobs:
       id: meta
       run: |
         echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-    - uses: rui314/setup-mold@v1
+    - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
     - name: cache for linux
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'Linux'
       with:
         path: |
@@ -43,7 +43,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: cache for macOS
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'macOS'
       with:
         path: |
@@ -57,7 +57,7 @@ jobs:
       env:
         VERSION: ${{ steps.meta.outputs.VERSION }}
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@b98a3b12e86552593f3e4e577ca8a62aa2f3f22b # v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ${{ matrix.artifact_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
     - name: cache for linux
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'Linux'
       with:
         path: |
@@ -31,7 +31,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: cache for macOS
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'macOS'
       with:
         path: |
@@ -43,7 +43,7 @@ jobs:
     - name: download modules
       run: |
         go mod download
-    - uses: rui314/setup-mold@v1
+    - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
     - name: build
       run: make emulator/build
       env:
@@ -67,13 +67,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: setup Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: cache for linux
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'Linux'
       with:
         path: |
@@ -83,7 +83,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: cache for macOS
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       if: runner.os == 'macOS'
       with:
         path: |
@@ -107,11 +107,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
     - name: build docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         load: true
@@ -119,13 +119,13 @@ jobs:
         platforms: linux/amd64
         push: false
     - name: setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version-file: test/python/.python-version
     - name: install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
     - name: cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/uv
         key: ${{ runner.os }}-uv-${{ hashFiles('test/python/uv.lock') }}
@@ -147,11 +147,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
     - name: build docker image
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         load: true
@@ -159,13 +159,13 @@ jobs:
         platforms: linux/amd64
         push: false
     - name: setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '24'
     - name: enable corepack
       run: corepack enable
     - name: cache yarn dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: test/node/.yarn/cache
         key: ${{ runner.os }}-yarn-${{ hashFiles('test/node/yarn.lock') }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions from mutable tags to immutable SHA commit refs
- Prevents tag-moving supply chain attacks (e.g., xygeni/xygeni-action, tj-actions/changed-files compromises)
- Covers all 3 workflow files: build.yml, release.yml, test.yml

## Changes
- Pin 37 action references (17 unique action+version pairs) across 3 workflow files
- Third-party: docker/*, rui314/setup-mold, svenstaro/upload-release-action, astral-sh/setup-uv
- GitHub first-party: actions/checkout, actions/cache, actions/setup-go, actions/setup-node, actions/setup-python, actions/upload-artifact, actions/download-artifact
- Original version tags preserved as inline comments for readability

## Test plan
- [ ] Build workflow still passes (triggered on tag push)
- [ ] Test workflow still passes (triggered on PR/push to main)
- [ ] Release workflow still passes (triggered on tag push)
- [ ] No functional changes — only reference format changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)